### PR TITLE
Add responder rebid after Stayman with integration tests

### DIFF
--- a/BridgeIt.Api/Program.cs
+++ b/BridgeIt.Api/Program.cs
@@ -74,6 +74,9 @@ builder.Services.AddSingleton<IEnumerable<IBiddingRule>>(_ => new List<IBiddingR
     new StaymanResponse(NTConventionContexts.After1NT),
     new StaymanResponse(NTConventionContexts.After2NT),
     new StaymanResponse(NTConventionContexts.After2C2D2NT),
+    new AcolResponderAfterStayman(NTConventionContexts.After1NT),
+    new AcolResponderAfterStayman(NTConventionContexts.After2NT),
+    new AcolResponderAfterStayman(NTConventionContexts.After2C2D2NT),
     new CompleteTransfer(NTConventionContexts.After1NT),
     new CompleteTransfer(NTConventionContexts.After2NT),
     new CompleteTransfer(NTConventionContexts.After2C2D2NT),
@@ -88,6 +91,7 @@ builder.Services.AddSingleton<IEnumerable<IBiddingRule>>(_ => new List<IBiddingR
     new KnowledgeBidGameInSuit(),
     new KnowledgeBidGameInNT(),
     new KnowledgeInviteInSuit(),
+    new KnowledgeInviteInNT(),
     new KnowledgeSignOffInFit(),
     new KnowledgeSignOff(),
 

--- a/BridgeIt.Core/BiddingEngine/Conventions/AcolResponderAfterStayman.cs
+++ b/BridgeIt.Core/BiddingEngine/Conventions/AcolResponderAfterStayman.cs
@@ -1,0 +1,108 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Conventions;
+
+/// <summary>
+/// Responder's rebid after a Stayman sequence (e.g. 1NT-2C-2D/2H/2S).
+/// Places the contract based on whether a major fit was found and combined strength.
+///
+/// With fit (4+4 in a major): raise to game (4M) or invite (3M).
+/// Without fit (2D denial or mismatched major): bid 3NT (game) or 2NT (invite).
+///
+/// Parameterised by NTConventionContext so the same class works after 1NT, 2NT, or 2C-2D-2NT.
+/// </summary>
+public class AcolResponderAfterStayman : BiddingRuleBase
+{
+    private readonly NTConventionContext _ntCtx;
+
+    public AcolResponderAfterStayman(NTConventionContext ntCtx, int priority = 55)
+    {
+        _ntCtx = ntCtx;
+        Priority = priority;
+    }
+
+    public override string Name => $"Responder after Stayman ({_ntCtx.Name})";
+    public override int Priority { get; }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+    {
+        if (auction.SeatRoleType != SeatRoleType.Responder) return false;
+        if (auction.AuctionPhase != AuctionPhase.Uncontested) return false;
+
+        // I must have bid Stayman last round
+        if (auction.MyLastNonPassBid != _ntCtx.StaymanBid) return false;
+
+        // Partner must have responded to Stayman (suit bid at convention level)
+        var partnerBid = auction.PartnerLastNonPassBid;
+        if (partnerBid == null || partnerBid.Type != BidType.Suit) return false;
+        if (partnerBid.Level != _ntCtx.ConventionLevel) return false;
+
+        // Partner's response should be D, H, or S (not C — that's the Stayman bid itself)
+        if (partnerBid.Suit == Suit.Clubs) return false;
+
+        return true;
+    }
+
+    protected override bool IsHandApplicable(DecisionContext ctx) => true;
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var partnerBid = ctx.AuctionEvaluation.PartnerLastNonPassBid!;
+        var fitSuit = FindFitSuit(partnerBid, ctx);
+        var verdict = ctx.GetLevelVerdict(25);
+
+        if (fitSuit != null)
+        {
+            // Major fit found — raise to game or invite
+            return verdict == LevelVerdict.BidGame
+                ? Bid.SuitBid(4, fitSuit.Value)
+                : Bid.SuitBid(3, fitSuit.Value);
+        }
+
+        // No fit — bid NT
+        return verdict == LevelVerdict.BidGame
+            ? Bid.NoTrumpsBid(3)
+            : Bid.NoTrumpsBid(2);
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+    {
+        // Bids this rule can explain: 4H, 4S, 3H, 3S, 3NT, 2NT
+        if (bid.Type == BidType.NoTrumps && (bid.Level == 2 || bid.Level == 3)) return true;
+        if (bid.Type == BidType.Suit && bid.Suit is Suit.Hearts or Suit.Spades && (bid.Level == 3 || bid.Level == 4)) return true;
+        return false;
+    }
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        var constraints = new CompositeConstraint();
+        constraints.Add(new HcpConstraint(_ntCtx.StaymanHcpMin, 30));
+
+        if (bid.Type == BidType.Suit && bid.Suit.HasValue)
+            constraints.Add(new SuitLengthConstraint(bid.Suit.Value, 4, 13));
+
+        var state = bid.Level >= 4 || (bid.Type == BidType.NoTrumps && bid.Level == 3)
+            ? PartnershipBiddingState.SignOff
+            : PartnershipBiddingState.GameInvitational;
+
+        return new BidInformation(bid, constraints, state);
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => new() { Constraints = { new HcpConstraint(_ntCtx.StaymanHcpMin, 30) } };
+
+    private static Suit? FindFitSuit(Bid partnerBid, DecisionContext ctx)
+    {
+        if (partnerBid.Suit == Suit.Hearts && ctx.HandEvaluation.Shape[Suit.Hearts] >= 4)
+            return Suit.Hearts;
+
+        if (partnerBid.Suit == Suit.Spades && ctx.HandEvaluation.Shape[Suit.Spades] >= 4)
+            return Suit.Spades;
+
+        return null;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInNT.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInNT.cs
@@ -1,0 +1,59 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
+
+/// <summary>
+/// Knowledge-based: bid 2NT as an invitation when combined HCP straddles game
+/// but no confirmed major suit fit exists.
+/// </summary>
+public class KnowledgeInviteInNT : BiddingRuleBase
+{
+    public override string Name => "Knowledge: Invite in NT";
+    public override int Priority { get; } = 1;
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.AuctionPhase != AuctionPhase.PreOpening;
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        if (ctx.AuctionEvaluation.PartnerLastNonPassBid == null) return false;
+        if (ctx.PartnershipBiddingState == PartnershipBiddingState.SignOff) return false;
+        if (ctx.GetLevelVerdict(25) != LevelVerdict.Invite) return false;
+
+        // No confirmed major fit
+        if (ctx.HasFitInSuit(Suit.Spades) || ctx.HasFitInSuit(Suit.Hearts))
+            return false;
+
+        // 2NT must be a legal bid
+        var current = ctx.AuctionEvaluation.CurrentContract;
+        if (current != null && !IsHigherBid(Bid.NoTrumpsBid(2), current))
+            return false;
+
+        return true;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        return Bid.NoTrumpsBid(2);
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+        => bid.Type == BidType.NoTrumps && bid.Level == 2;
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+        => new(bid, null, PartnershipBiddingState.GameInvitational);
+
+    private static bool IsHigherBid(Bid newBid, Bid current)
+    {
+        if (newBid.Level > current.Level) return true;
+        if (newBid.Level == current.Level)
+        {
+            if (newBid.Type == BidType.NoTrumps && current.Type == BidType.Suit) return true;
+            if (newBid.Suit > current.Suit) return true;
+        }
+        return false;
+    }
+}

--- a/BridgeIt.Dealer/HandSpecifications/HandSpecification.cs
+++ b/BridgeIt.Dealer/HandSpecifications/HandSpecification.cs
@@ -269,6 +269,46 @@ public static class HandSpecification
         && ShapeEvaluator.LongestAndStrongest(h) == suit;
 
     // =============================================
+    // After Stayman — Responder's rebid scenarios
+    // =============================================
+
+    // Game-forcing (13+), exactly 4 hearts (may or may not have 4 spades)
+    public static Func<Hand, bool> AfterStayman_GameForcing_WithHearts => h =>
+        HighCardPoints.Count(h) >= 13 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] < 5;
+
+    // Game-forcing (13+), exactly 4 spades, <4 hearts
+    public static Func<Hand, bool> AfterStayman_GameForcing_WithSpades => h =>
+        HighCardPoints.Count(h) >= 13 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4;
+
+    // Game-forcing (13+), both 4 hearts and 4 spades
+    public static Func<Hand, bool> AfterStayman_GameForcing_BothMajors => h =>
+        HighCardPoints.Count(h) >= 13 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] == 4;
+
+    // Invitational (11-12), exactly 4 hearts (may or may not have 4 spades)
+    public static Func<Hand, bool> AfterStayman_Invitational_WithHearts => h =>
+        HighCardPoints.Count(h) >= 11 && HighCardPoints.Count(h) <= 12 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] < 5;
+
+    // Invitational (11-12), exactly 4 spades, <4 hearts
+    public static Func<Hand, bool> AfterStayman_Invitational_WithSpades => h =>
+        HighCardPoints.Count(h) >= 11 && HighCardPoints.Count(h) <= 12 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4;
+
+    // Invitational (11-12), both 4 hearts and 4 spades
+    public static Func<Hand, bool> AfterStayman_Invitational_BothMajors => h =>
+        HighCardPoints.Count(h) >= 11 && HighCardPoints.Count(h) <= 12 &&
+        ShapeEvaluator.GetShape(h)[Suit.Hearts] == 4 &&
+        ShapeEvaluator.GetShape(h)[Suit.Spades] == 4;
+
+    // =============================================
     // Opponent Specs (for uncontested test scenarios)
     // =============================================
 

--- a/BridgeIt.TestHarness/Setup/TestBridgeEnvironment.cs
+++ b/BridgeIt.TestHarness/Setup/TestBridgeEnvironment.cs
@@ -96,6 +96,10 @@ public class TestBridgeEnvironment
         rules.Add(new StaymanResponse(NTConventionContexts.After2NT));
         rules.Add(new StaymanResponse(NTConventionContexts.After2C2D2NT));
 
+        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After1NT));
+        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After2NT));
+        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After2C2D2NT));
+
         // Opener rebid rules
         rules.Add(new AcolOpenerAfterNTInvite());
         rules.Add(new AcolOpenerAfterMajorRaise());
@@ -108,6 +112,7 @@ public class TestBridgeEnvironment
         rules.Add(new KnowledgeBidGameInSuit());
         rules.Add(new KnowledgeBidGameInNT());
         rules.Add(new KnowledgeInviteInSuit());
+        rules.Add(new KnowledgeInviteInNT());
         rules.Add(new KnowledgeSignOffInFit());
         rules.Add(new KnowledgeSignOff());
 

--- a/BridgeIt.TestHarness/SystemTests/Acol/1NT_opening/AfterStaymanTests.cs
+++ b/BridgeIt.TestHarness/SystemTests/Acol/1NT_opening/AfterStaymanTests.cs
@@ -1,0 +1,270 @@
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Dealer.HandSpecifications;
+using BridgeIt.TestHarness.Setup;
+using NUnit.Framework;
+
+namespace BridgeIt.TestHarness.SystemTests.Acol._1NT_opening;
+
+/// <summary>
+/// System tests for responder's rebid after a Stayman sequence:
+/// 1NT -> 2C -> 2D/2H/2S -> responder places the contract.
+///
+/// Scenarios:
+/// - Fit found (4+4 in a major) → raise to game (4M) or invite (3M)
+/// - No fit → bid 3NT (game) or 2NT (invite)
+/// </summary>
+[TestFixture]
+public class AfterStaymanTests
+{
+    private TestBridgeEnvironment _environment;
+    private Dealer.Deal.Dealer _dealer;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        _environment = TestBridgeEnvironment.Create().WithAllRules();
+        _dealer = new Dealer.Deal.Dealer();
+    }
+
+    // =============================================
+    // After 2D denial (opener has no 4-card major)
+    // =============================================
+
+    [Test]
+    public async Task AfterStayman_2D_GameForcing_Bids3NT()
+    {
+        // Opener: 12-14 balanced, no 4-card major
+        Func<Hand, bool> openerNoMajor = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] < 4;
+
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerNoMajor,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_GameForcing_BothMajors);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2D"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("3NT"),
+                $"Expected 3NT with 13+ HCP and no fit. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    [Test]
+    public async Task AfterStayman_2D_Invitational_Bids2NT()
+    {
+        // Opener: 12-14 balanced, no 4-card major
+        Func<Hand, bool> openerNoMajor = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] < 4;
+
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerNoMajor,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_Invitational_BothMajors);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2D"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("2NT"),
+                $"Expected 2NT invite with 11-12 HCP and no fit. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    // =============================================
+    // After 2H (opener shows 4+ hearts)
+    // =============================================
+
+    [Test]
+    public async Task AfterStayman_2H_HeartFit_GameForcing_Bids4H()
+    {
+        // Opener: 12-14 balanced with 4+ hearts
+        Func<Hand, bool> openerWith4Hearts = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] >= 4;
+
+        // Responder: 13+ HCP, exactly 4 hearts (has the fit)
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4Hearts,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_GameForcing_WithHearts);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2H"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("4H"),
+                $"Expected 4H with heart fit and 13+ HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    [Test]
+    public async Task AfterStayman_2H_HeartFit_Invitational_Bids3H()
+    {
+        // Opener: 12-14 balanced with 4+ hearts
+        Func<Hand, bool> openerWith4Hearts = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] >= 4;
+
+        // Responder: 11-12 HCP, exactly 4 hearts (has the fit)
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4Hearts,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_Invitational_WithHearts);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2H"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("3H"),
+                $"Expected 3H invite with heart fit and 11-12 HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    [Test]
+    public async Task AfterStayman_2H_NoFit_GameForcing_Bids3NT()
+    {
+        // Opener: 12-14 balanced with 4+ hearts but <4 spades
+        Func<Hand, bool> openerWith4HeartsNoSpades = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] >= 4
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] < 4;
+
+        // Responder: 13+ HCP, exactly 4 spades, <4 hearts (no heart fit)
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4HeartsNoSpades,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_GameForcing_WithSpades);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2H"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("3NT"),
+                $"Expected 3NT with no heart fit and 13+ HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    [Test]
+    public async Task AfterStayman_2H_NoFit_Invitational_Bids2NT()
+    {
+        // Opener: 12-14 balanced with 4+ hearts but <4 spades
+        Func<Hand, bool> openerWith4HeartsNoSpades = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] >= 4
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] < 4;
+
+        // Responder: 11-12 HCP, exactly 4 spades, <4 hearts (no heart fit)
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4HeartsNoSpades,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_Invitational_WithSpades);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2H"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("2NT"),
+                $"Expected 2NT invite with no heart fit and 11-12 HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    // =============================================
+    // After 2S (opener shows 4+ spades, denied hearts)
+    // =============================================
+
+    [Test]
+    public async Task AfterStayman_2S_SpadeFit_GameForcing_Bids4S()
+    {
+        // Opener: 12-14 balanced with 4+ spades, <4 hearts
+        Func<Hand, bool> openerWith4SpadesNoHearts = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] >= 4
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4;
+
+        // Responder: 13+ HCP, exactly 4 spades (has the fit)
+        // Use GameForcing_WithSpades since responder has 4 spades
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4SpadesNoHearts,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_GameForcing_WithSpades);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2S"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("4S"),
+                $"Expected 4S with spade fit and 13+ HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+
+    [Test]
+    public async Task AfterStayman_2S_SpadeFit_Invitational_Bids3S()
+    {
+        // Opener: 12-14 balanced with 4+ spades, <4 hearts
+        Func<Hand, bool> openerWith4SpadesNoHearts = h =>
+            HighCardPoints.Count(h) >= 12 && HighCardPoints.Count(h) <= 14
+            && ShapeEvaluator.IsBalanced(h)
+            && ShapeEvaluator.GetShape(h)[Suit.Spades] >= 4
+            && ShapeEvaluator.GetShape(h)[Suit.Hearts] < 4;
+
+        // Responder: 11-12 HCP, exactly 4 spades (has the fit)
+        var testDeals = _dealer.GenerateMultipleConstrainedDeals(
+            50,
+            openerWith4SpadesNoHearts,
+            HandSpecification.PassingOpponent,
+            HandSpecification.AfterStayman_Invitational_WithSpades);
+
+        foreach (var deal in testDeals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1NT"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[2].Bid.ToString(), Is.EqualTo("2C"), $"S: {deal[Seat.South]}");
+            Assert.That(auction.Bids[4].Bid.ToString(), Is.EqualTo("2S"), $"N: {deal[Seat.North]}");
+            Assert.That(auction.Bids[6].Bid.ToString(), Is.EqualTo("3S"),
+                $"Expected 3S invite with spade fit and 11-12 HCP. S: {deal[Seat.South]}, N: {deal[Seat.North]}");
+        }
+    }
+}


### PR DESCRIPTION
Implement AcolResponderAfterStayman convention rule to place the contract after a Stayman sequence (1NT-2C-2D/2H/2S). Handles fit (raise to 4M/3M) and no-fit (3NT/2NT) based on combined HCP verdict. Also adds KnowledgeInviteInNT as a general catch-all for NT invites, 6 new HandSpecifications for after-Stayman scenarios, and 8 integration tests covering all game/invite × fit/no-fit combinations.