### PR TITLE
Add StopperQuality enum replacing bool stopper system

### DIFF
--- a/BridgeIt.Core/Analysis/Hands/HandEvaluation.cs
+++ b/BridgeIt.Core/Analysis/Hands/HandEvaluation.cs
@@ -12,7 +12,7 @@ public class HandEvaluation
     public bool IsBalanced { get; init; }
     public Dictionary<Suit,int> RomanKeyCardCount { get; init; } = new();
     public Suit LongestAndStrongest {get; init;}
-    public Dictionary<Suit, bool> SuitStoppers { get; init; } = new();
+    public Dictionary<Suit, StopperQuality> SuitStoppers { get; init; } = new();
 
     /// <summary>
     /// Returns all suits with at least <paramref name="minLength"/> cards,

--- a/BridgeIt.Core/Analysis/Hands/ShapeEvaluator.cs
+++ b/BridgeIt.Core/Analysis/Hands/ShapeEvaluator.cs
@@ -74,24 +74,41 @@ public static class ShapeEvaluator
             .ToList();
     }
 
-    public static Dictionary<Suit, bool> GetStoppers(Hand hand)
+    public static Dictionary<Suit, StopperQuality> GetStoppers(Hand hand)
     {
-        var stoppers = new Dictionary<Suit, bool>();
+        var stoppers = new Dictionary<Suit, StopperQuality>();
         foreach (Suit suit in Enum.GetValues(typeof(Suit)))
         {
-            stoppers[suit] = HasStopperInSuit(hand, suit);
+            stoppers[suit] = EvaluateStopperQuality(hand, suit);
         }
 
         return stoppers;
     }
 
-    private static bool HasStopperInSuit(Hand hand, Suit suit)
+    internal static StopperQuality EvaluateStopperQuality(Hand hand, Suit suit)
     {
         var suitCards = hand.Cards.Where(x => x.Suit == suit).ToList();
-        
-        var countCards = suitCards.Count;
-        
-        return suitCards.Any(x => x.Rank == Rank.Ace || x.Rank == Rank.King && countCards >= 2 || x.Rank == Rank.Queen && countCards >= 3 || x.Rank == Rank.Jack && countCards >= 4);
+        var count = suitCards.Count;
+
+        if (count == 0) return StopperQuality.None;
+
+        var hasAce = suitCards.Any(c => c.Rank == Rank.Ace);
+        var hasKing = suitCards.Any(c => c.Rank == Rank.King);
+        var hasQueen = suitCards.Any(c => c.Rank == Rank.Queen);
+        var hasJack = suitCards.Any(c => c.Rank == Rank.Jack);
+
+        // Full stoppers: A, Kx+, Qxx+, Jxxx+
+        if (hasAce) return StopperQuality.Full;
+        if (hasKing && count >= 2) return StopperQuality.Full;
+        if (hasQueen && count >= 3) return StopperQuality.Full;
+        if (hasJack && count >= 4) return StopperQuality.Full;
+
+        // Partial stoppers: singleton K, Qx, QJ, Jxx
+        if (hasKing) return StopperQuality.Partial;  // singleton K
+        if (hasQueen && count >= 2) return StopperQuality.Partial;  // Qx
+        if (hasJack && count >= 3) return StopperQuality.Partial;  // Jxx
+
+        return StopperQuality.None;
     }
 
 }

--- a/BridgeIt.Core/Analysis/Hands/StopperQuality.cs
+++ b/BridgeIt.Core/Analysis/Hands/StopperQuality.cs
@@ -1,0 +1,14 @@
+namespace BridgeIt.Core.Analysis.Hands;
+
+/// <summary>
+/// Represents the quality of a stopper in a suit.
+/// None: no useful high cards for stopping the suit.
+/// Partial: a half-stopper that may combine with partner's holding (e.g. Qx, Jxx, singleton K).
+/// Full: a definite stopper (e.g. A, Kx, Qxx, Jxxx).
+/// </summary>
+public enum StopperQuality
+{
+    None,
+    Partial,
+    Full
+}

--- a/BridgeIt.Core/BiddingEngine/Constraints/StopperConstraint.cs
+++ b/BridgeIt.Core/BiddingEngine/Constraints/StopperConstraint.cs
@@ -1,0 +1,28 @@
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Constraints;
+
+/// <summary>
+/// Constraint that checks whether a hand has the required stopper quality in a given suit.
+/// </summary>
+public class StopperConstraint : IBidConstraint
+{
+    public Suit Suit { get; }
+    public StopperQuality MinQuality { get; }
+
+    public StopperConstraint(Suit suit, StopperQuality minQuality = StopperQuality.Full)
+    {
+        Suit = suit;
+        MinQuality = minQuality;
+    }
+
+    public bool IsMet(DecisionContext ctx)
+    {
+        if (!ctx.HandEvaluation.SuitStoppers.TryGetValue(Suit, out var quality))
+            return false;
+
+        return quality >= MinQuality;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/AcolResponseToWeakPreempt.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/AcolResponseToWeakPreempt.cs
@@ -1,4 +1,5 @@
 using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
 using BridgeIt.Core.BiddingEngine.Constraints;
 using BridgeIt.Core.BiddingEngine.Core;
 using BridgeIt.Core.Domain.Bidding;
@@ -145,14 +146,14 @@ public class AcolResponseToWeakPreempt : BiddingRuleBase
         return null;
     }
 
-    private static bool HasStoppersInUnbidSuits(Dictionary<Suit, bool> stoppers, Suit partnerSuit)
+    private static bool HasStoppersInUnbidSuits(Dictionary<Suit, StopperQuality> stoppers, Suit partnerSuit)
     {
         foreach (Suit s in Enum.GetValues(typeof(Suit)))
         {
             if (s == partnerSuit)
                 continue;
 
-            if (!stoppers.TryGetValue(s, out var hasStopper) || !hasStopper)
+            if (!stoppers.TryGetValue(s, out var quality) || quality < StopperQuality.Full)
                 return false;
         }
 

--- a/BridgeIt.Tests/Analysis/Hands/ShapeEvaluatorTests.cs
+++ b/BridgeIt.Tests/Analysis/Hands/ShapeEvaluatorTests.cs
@@ -1,4 +1,5 @@
 using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Domain.Extensions;
 using BridgeIt.Core.Domain.Primatives;
 
 namespace BridgeIt.Tests.Analysis.Hand;
@@ -276,6 +277,115 @@ public class ShapeEvaluatorTests
         Assert.That(result, Has.Count.EqualTo(4));
         Assert.That(result[0], Is.EqualTo(Suit.Spades));
         Assert.That(result[3], Is.EqualTo(Suit.Clubs));
+    }
+
+    // --- GetStoppers / EvaluateStopperQuality Tests ---
+
+    [Test]
+    [Description("Ace is always a full stopper, even as singleton")]
+    public void EvaluateStopperQuality_Ace_IsFull()
+    {
+        // SA HKQ532 DJT97 C42 — singleton ace of spades
+        var hand = "SA HKQ532 DJT97 C42".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Full));
+    }
+
+    [Test]
+    [Description("Kx is a full stopper")]
+    public void EvaluateStopperQuality_KingWithGuard_IsFull()
+    {
+        // SK2 HAQJ9 DT873 C65
+        var hand = "SK2 HAQJ9 DT873 C65".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Full));
+    }
+
+    [Test]
+    [Description("Qxx is a full stopper")]
+    public void EvaluateStopperQuality_QueenWithTwoGuards_IsFull()
+    {
+        // SQ52 HAK98 DJT73 C64
+        var hand = "SQ52 HAK98 DJT73 C64".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Full));
+    }
+
+    [Test]
+    [Description("Jxxx is a full stopper")]
+    public void EvaluateStopperQuality_JackWithThreeGuards_IsFull()
+    {
+        // SJ532 HAK98 DQT7 C6
+        var hand = "SJ532 HAK98 DQT7 C6".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Full));
+    }
+
+    [Test]
+    [Description("Singleton King is a partial stopper")]
+    public void EvaluateStopperQuality_SingletonKing_IsPartial()
+    {
+        // SK HAQ9876 DJT3 C42
+        var hand = "SK HAQ9876 DJT3 C42".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Partial));
+    }
+
+    [Test]
+    [Description("Qx is a partial stopper")]
+    public void EvaluateStopperQuality_QueenWithOneGuard_IsPartial()
+    {
+        // SQ2 HAK987 DJT63 C54
+        var hand = "SQ2 HAK987 DJT63 C54".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Partial));
+    }
+
+    [Test]
+    [Description("Jxx is a partial stopper")]
+    public void EvaluateStopperQuality_JackWithTwoGuards_IsPartial()
+    {
+        // SJ52 HAK987 DQT3 C64
+        var hand = "SJ52 HAK987 DQT3 C64".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.Partial));
+    }
+
+    [Test]
+    [Description("Small cards only is no stopper")]
+    public void EvaluateStopperQuality_SmallCardsOnly_IsNone()
+    {
+        // S532 HAKQ9 DJT87 C64
+        var hand = "S532 HAKQ9 DJT87 C64".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.None));
+    }
+
+    [Test]
+    [Description("Void is no stopper")]
+    public void EvaluateStopperQuality_Void_IsNone()
+    {
+        // HAKQ98 DJT732 C654 — void in spades
+        var hand = "HAKQ98 DJT732 C654".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.None));
+    }
+
+    [Test]
+    [Description("Singleton Queen is no stopper")]
+    public void EvaluateStopperQuality_SingletonQueen_IsNone()
+    {
+        // SQ HAK98765 DJT3 C2
+        var hand = "SQ HAK98765 DJT3 C2".ToHand();
+        Assert.That(ShapeEvaluator.EvaluateStopperQuality(hand, Suit.Spades), Is.EqualTo(StopperQuality.None));
+    }
+
+    [Test]
+    [Description("GetStoppers returns quality for all four suits")]
+    public void GetStoppers_ReturnsAllFourSuits()
+    {
+        // SAKQ HJ32 D9876 C54 — S=Full, H=Partial(Jxx), D=None, C=None
+        var hand = "SAKQ HJ32 D9876 C54".ToHand();
+        var stoppers = ShapeEvaluator.GetStoppers(hand);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stoppers[Suit.Spades], Is.EqualTo(StopperQuality.Full));
+            Assert.That(stoppers[Suit.Hearts], Is.EqualTo(StopperQuality.Partial));
+            Assert.That(stoppers[Suit.Diamonds], Is.EqualTo(StopperQuality.None));
+            Assert.That(stoppers[Suit.Clubs], Is.EqualTo(StopperQuality.None));
+        });
     }
 
     // --- Helper for constructing hands by shape ---

--- a/BridgeIt.Tests/BiddingEngine/Constraints/ConstraintTests.cs
+++ b/BridgeIt.Tests/BiddingEngine/Constraints/ConstraintTests.cs
@@ -65,6 +65,28 @@ public class AllConstraintTests
         Assert.That(expected, Is.EqualTo(constraint.IsMet(ctx)));
     }
 
+    [TestCase(StopperQuality.Full, StopperQuality.Full, true)]
+    [TestCase(StopperQuality.Partial, StopperQuality.Full, false)]
+    [TestCase(StopperQuality.None, StopperQuality.Full, false)]
+    [TestCase(StopperQuality.Full, StopperQuality.Partial, true)]
+    [TestCase(StopperQuality.Partial, StopperQuality.Partial, true)]
+    [TestCase(StopperQuality.None, StopperQuality.Partial, false)]
+    public void StopperConstraint_EvaluatesCorrectly(StopperQuality actual, StopperQuality required, bool expected)
+    {
+        var constraint = new StopperConstraint(Suit.Hearts, required);
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, actual } };
+        var ctx = TestHelper.CreateContext(eval: new HandEvaluation { SuitStoppers = stoppers });
+        Assert.That(expected, Is.EqualTo(constraint.IsMet(ctx)));
+    }
+
+    [Test]
+    public void StopperConstraint_MissingSuit_ReturnsFalse()
+    {
+        var constraint = new StopperConstraint(Suit.Hearts, StopperQuality.Partial);
+        var ctx = TestHelper.CreateContext(eval: new HandEvaluation { SuitStoppers = new Dictionary<Suit, StopperQuality>() });
+        Assert.That(constraint.IsMet(ctx), Is.False);
+    }
+
     // ==============================================================================
     // 2. SYSTEM STATE CONSTRAINTS (CurrentState, HistoryPattern)
     // ==============================================================================

--- a/BridgeIt.Tests/Rules/KnowledgeRuleTests.cs
+++ b/BridgeIt.Tests/Rules/KnowledgeRuleTests.cs
@@ -59,10 +59,10 @@ public class KnowledgeRuleTests
             IsBalanced = myShape.Values.All(v => v >= 2) && myShape.Values.Count(v => v <= 3) >= 2,
             Losers = 7,
             LongestAndStrongest = myShape.OrderByDescending(kv => kv.Value).First().Key,
-            SuitStoppers = new Dictionary<Suit, bool>
+            SuitStoppers = new Dictionary<Suit, StopperQuality>
             {
-                { Suit.Spades, true }, { Suit.Hearts, true },
-                { Suit.Diamonds, true }, { Suit.Clubs, true }
+                { Suit.Spades, StopperQuality.Full }, { Suit.Hearts, StopperQuality.Full },
+                { Suit.Diamonds, StopperQuality.Full }, { Suit.Clubs, StopperQuality.Full }
             }
         };
 


### PR DESCRIPTION
Replace Dictionary<Suit, bool> with Dictionary<Suit, StopperQuality> using a three-level enum (None, Partial, Full) for more nuanced stopper evaluation.

- StopperQuality.Full: A, Kx+, Qxx+, Jxxx+ (definite stoppers)
- StopperQuality.Partial: singleton K, Qx, Jxx (half-stoppers)
- StopperQuality.None: no useful high cards

Add StopperConstraint for use in bidding rules. Update ShapeEvaluator, HandEvaluation, AcolResponseToWeakPreempt, and all test references. Add comprehensive tests for stopper quality evaluation and constraint.

https://claude.ai/code/session_01GWM2FyiVad7VU4rNtoU989