### PR TITLE
Add BiddingSystemLoader with typed config records and 4 system defini…

### DIFF
--- a/BridgeIt.Api/BridgeIt.Api.csproj
+++ b/BridgeIt.Api/BridgeIt.Api.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
       <ProjectReference Include="..\BridgeIt.Core\BridgeIt.Core.csproj" />
       <ProjectReference Include="..\BridgeIt.Dealer\BridgeIt.Dealer.csproj" />
+      <ProjectReference Include="..\BridgeIt.Systems\BridgeIt.Systems.csproj" />
       <ProjectReference Include="..\BridgeIt.TestHarness\BridgeIt.TestHarness.csproj" />
     </ItemGroup>
 

--- a/BridgeIt.Api/Hubs/GameHubs.cs
+++ b/BridgeIt.Api/Hubs/GameHubs.cs
@@ -157,4 +157,28 @@ public class GameHub : Hub
     {
         await Clients.Caller.SendAsync("GetAllHands", _gameService.GetAllHands());
     }
+
+    // ─── System management ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Hot-swap the bidding system. Accepts a full BridgeSystemConfig JSON string.
+    /// The new system takes effect on the next auction.
+    /// </summary>
+    public async Task LoadSystem(string systemJson)
+    {
+        try
+        {
+            var loaded = _gameService.LoadSystem(systemJson);
+            await Clients.Caller.SendAsync("SystemLoaded", new
+            {
+                name = loaded.Name,
+                ruleCount = loaded.Rules.Count,
+                warnings = loaded.Warnings
+            });
+        }
+        catch (Exception ex)
+        {
+            await Clients.Caller.SendAsync("SystemMessage", $"Failed to load system: {ex.Message}");
+        }
+    }
 }

--- a/BridgeIt.Api/Program.cs
+++ b/BridgeIt.Api/Program.cs
@@ -1,21 +1,12 @@
 using BridgeIt.Api.Hubs;
 using BridgeIt.Api.Services;
-using BridgeIt.Core.BiddingEngine.EngineObserver;
-using BridgeIt.Core.Extensions;
-using BridgeIt.Core.BiddingEngine.Conventions;
 using BridgeIt.Core.BiddingEngine.Core;
-using BridgeIt.Core.BiddingEngine.Rules.Knowledge;
-using BridgeIt.Core.BiddingEngine.Rules.Openings;
-using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1NT;
-using BridgeIt.Core.BiddingEngine.Rules.Responder;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
-using BridgeIt.Core.Domain.Bidding;
-using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Core.BiddingEngine.EngineObserver;
 using BridgeIt.Core.Domain.IBidValidityChecker;
+using BridgeIt.Core.Extensions;
 using BridgeIt.Core.Gameplay.Output;
 using BridgeIt.Core.Gameplay.Table;
+using BridgeIt.Systems;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,73 +33,17 @@ builder.Services.AddSingleton<IBidValidityChecker, BidValidityChecker>();
 
 
 
-// --- 4. Register Bidding Rules ---
-builder.Services.AddSingleton<IEnumerable<IBiddingRule>>(_ => new List<IBiddingRule>
+// --- 4. Register Bidding System ---
+builder.Services.AddSingleton<BiddingSystemLoader>();
+builder.Services.AddSingleton(sp =>
 {
-    // Openings
-    new Acol1NTOpeningRule(),
-    new Acol1SuitOpeningRule(),
-    new Acol2NTOpeningRule(),
-    new AcolStrongOpening(),
-    new WeakOpeningRule(new[] { Bid.SuitBid(2, Suit.Clubs) }), // 2C reserved for strong opening
-
-    // Response to 2C
-    new AcolResponseTo2C(),
-
-    // Responses to 1-suit
-    new AcolJacoby2NTOver1Major(),
-    new AcolRaiseMajorOver1Suit(),
-    new AcolRaiseMinorOver1Suit(),
-    new AcolNewSuitOver1Suit(),
-    new Acol1NTResponseTo1Suit(),
-
-    // Responses to 1NT
-    new StandardStayman(NTConventionContexts.After1NT),
-    new StandardTransfer(NTConventionContexts.After1NT),
-    new AcolNTRaiseOver1NT(),
-
-    // Responses to 2NT
-    new StandardStayman(NTConventionContexts.After2NT),
-    new StandardTransfer(NTConventionContexts.After2NT),
-
-    // Responses to 2C-2D-2NT
-    new StandardStayman(NTConventionContexts.After2C2D2NT),
-    new StandardTransfer(NTConventionContexts.After2C2D2NT),
-
-    // Opener rebids
-    new AcolOpenerRebidAfter2C(),
-    new StaymanResponse(NTConventionContexts.After1NT),
-    new StaymanResponse(NTConventionContexts.After2NT),
-    new StaymanResponse(NTConventionContexts.After2C2D2NT),
-    new AcolResponderAfterStayman(NTConventionContexts.After1NT),
-    new AcolResponderAfterStayman(NTConventionContexts.After2NT),
-    new AcolResponderAfterStayman(NTConventionContexts.After2C2D2NT),
-    new CompleteTransfer(NTConventionContexts.After1NT),
-    new CompleteTransfer(NTConventionContexts.After2NT),
-    new CompleteTransfer(NTConventionContexts.After2C2D2NT),
-    new AcolOpenerAfterNTInvite(),
-    new AcolOpenerAfterMajorRaise(),
-    new AcolRebidBalanced(),
-    new AcolRebidNewSuit(),
-    new AcolRebidRaiseSuit(),
-    new AcolRebidOwnSuit(),
-
-    // Responder rebids (round 2)
-    new AcolResponderAfterOpenerRaisedSuit(),
-    new AcolResponderAfterOpener1NTRebid(),
-    new AcolResponderAfterOpener2NTRebid(),
-    new AcolResponderAfterOpenerRebidOwnSuit(),
-    new AcolResponderAfterOpenerNewSuit(),
-
-    // Knowledge-based catch-all rules (low priority — fire when no pattern rule matches)
-    new KnowledgeBidGameInSuit(),
-    new KnowledgeBidGameInNT(),
-    new KnowledgeInviteInSuit(),
-    new KnowledgeInviteInNT(),
-    new KnowledgeSignOffInFit(),
-    new KnowledgeSignOff(),
-
-}.OrderByDescending(r => r.Priority).ToList());
+    var loader = sp.GetRequiredService<BiddingSystemLoader>();
+    var systemPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..",
+        "BridgeIt.Systems", "Systems", "acol-foundation.json");
+    return loader.LoadFromFile(systemPath);
+});
+builder.Services.AddSingleton<IEnumerable<IBiddingRule>>(sp =>
+    sp.GetRequiredService<LoadedSystem>().Rules);
 
 // --- 5. Configure CORS ---
 builder.Services.AddCors(options =>

--- a/BridgeIt.Api/Services/GameService.cs
+++ b/BridgeIt.Api/Services/GameService.cs
@@ -10,6 +10,7 @@ using BridgeIt.Core.Domain.Primatives;
 using BridgeIt.Core.Gameplay.Table;
 using BridgeIt.Core.Players;
 using BridgeIt.Dealer.HandSpecifications;
+using BridgeIt.Systems;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BridgeIt.Api.Services;
@@ -35,21 +36,44 @@ public class GameService
 
     private CancellationTokenSource? _gameCts;
 
+    private readonly BiddingSystemLoader _systemLoader;
+
     public GameService(
         BiddingEngine biddingEngine,
         IBidValidityChecker bidValidityChecker,
         BiddingTable table,
         IRuleLookupService ruleLookupService,
+        BiddingSystemLoader systemLoader,
         IHubContext<GameHub> hubContext)
     {
         _biddingEngine = biddingEngine;
         _bidValidityChecker = bidValidityChecker;
         _table = table;
         _lookup = ruleLookupService;
+        _systemLoader = systemLoader;
         _hubContext = hubContext;
 
         foreach (Seat seat in Enum.GetValues(typeof(Seat)))
             _players[seat] = new RobotPlayer(_biddingEngine, _lookup);
+    }
+
+    /// <summary>
+    /// Hot-swap the bidding system. Loads a new rule set from JSON config
+    /// and swaps it into the engine. Takes effect on the next auction.
+    /// </summary>
+    public LoadedSystem LoadSystem(string systemJson)
+    {
+        var loaded = _systemLoader.LoadFromJson(systemJson);
+        _biddingEngine.SetRules(loaded.Rules);
+
+        // Rebuild robot players so they use the updated engine
+        foreach (Seat seat in Enum.GetValues(typeof(Seat)))
+        {
+            if (_players[seat] is RobotPlayer)
+                _players[seat] = new RobotPlayer(_biddingEngine, _lookup);
+        }
+
+        return loaded;
     }
 
     // ─── Player registration ──────────────────────────────────────────────────

--- a/BridgeIt.Core/BiddingEngine/Core/BiddingEngine.cs
+++ b/BridgeIt.Core/BiddingEngine/Core/BiddingEngine.cs
@@ -10,7 +10,7 @@ namespace BridgeIt.Core.BiddingEngine.Core;
 
 public sealed class BiddingEngine
 {
-    private readonly List<IBiddingRule> _rules;
+    private List<IBiddingRule> _rules;
     private readonly ILogger<BiddingEngine> _logger;
     private readonly IEngineObserver _observer;
     private readonly IBidValidityChecker _validityChecker;
@@ -92,6 +92,14 @@ public sealed class BiddingEngine
         _logger = logger;
         _observer = observer;
         _validityChecker = validityChecker ?? new BidValidityChecker();
+    }
+
+    /// <summary>
+    /// Hot-swap the rule set. Safe to call between auctions (auction loop is sequential).
+    /// </summary>
+    public void SetRules(IEnumerable<IBiddingRule> rules)
+    {
+        _rules = rules.OrderByDescending(r => r.Priority).ToList();
     }
 
     public BidResult ChooseBid(DecisionContext ctx)

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeBidGameInNT.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeBidGameInNT.cs
@@ -13,7 +13,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeBidGameInNT : BiddingRuleBase
 {
     public override string Name => "Knowledge: Bid 3NT";
-    public override int Priority { get; } = 1; // Below suit game — prefer suit fit
+    public override int Priority { get; } // Below suit game — prefer suit fit
+
+    public KnowledgeBidGameInNT(int priority = 1)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeBidGameInSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeBidGameInSuit.cs
@@ -14,7 +14,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeBidGameInSuit : BiddingRuleBase
 {
     public override string Name => "Knowledge: Bid game in suit";
-    public override int Priority { get; } = 2;
+    public override int Priority { get; }
+
+    public KnowledgeBidGameInSuit(int priority = 2)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInNT.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInNT.cs
@@ -12,7 +12,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeInviteInNT : BiddingRuleBase
 {
     public override string Name => "Knowledge: Invite in NT";
-    public override int Priority { get; } = 1;
+    public override int Priority { get; }
+
+    public KnowledgeInviteInNT(int priority = 1)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeInviteInSuit.cs
@@ -14,7 +14,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeInviteInSuit : BiddingRuleBase
 {
     public override string Name => "Knowledge: Invite in suit";
-    public override int Priority { get; } = 2;
+    public override int Priority { get; }
+
+    public KnowledgeInviteInSuit(int priority = 2)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeSignOff.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeSignOff.cs
@@ -17,7 +17,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeSignOff : BiddingRuleBase
 {
     public override string Name => "Knowledge: Sign off (pass)";
-    public override int Priority { get; } = 0; // Absolute lowest — true catch-all
+    public override int Priority { get; } // Absolute lowest — true catch-all
+
+    public KnowledgeSignOff(int priority = 0)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeSignOffInFit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Knowledge/KnowledgeSignOffInFit.cs
@@ -14,7 +14,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Knowledge;
 public class KnowledgeSignOffInFit : BiddingRuleBase
 {
     public override string Name => "Knowledge: Sign off in fit";
-    public override int Priority { get; } = 1;
+    public override int Priority { get; }
+
+    public KnowledgeSignOffInFit(int priority = 1)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
         => auction.AuctionPhase != AuctionPhase.PreOpening;

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterMajorRaise.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterMajorRaise.cs
@@ -9,7 +9,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolOpenerAfterMajorRaise : BiddingRuleBase
 {
     public override string Name { get; } = "After major raise";
-    public override int Priority { get; } = 45;
+    public override int Priority { get; }
+
+    public AcolOpenerAfterMajorRaise(int priority = 45)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterNTInvite.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterNTInvite.cs
@@ -8,8 +8,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolOpenerAfterNTInvite : BiddingRuleBase
 {
     public override string Name { get; } = "Acol opener after NT invite";
-    public override int Priority { get; } = 50;
+    public override int Priority { get; }
 
+    public AcolOpenerAfterNTInvite(int priority = 50)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerRebidAfter2C.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolOpenerRebidAfter2C.cs
@@ -9,7 +9,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolOpenerRebidAfter2C : BiddingRuleBase
 {
     public override string Name { get; } = "Acol opener rebid after 2C";
-    public override int Priority { get; } = 60;
+    public override int Priority { get; }
+
+    public AcolOpenerRebidAfter2C(int priority = 60)
+    {
+        Priority = priority;
+    }
 
     private const int MinHcp2NT = 23;
     private const int MaxHcp2NT = 24;

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidBalanced.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidBalanced.cs
@@ -8,7 +8,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolRebidBalanced : BiddingRuleBase
 {
     public override string Name { get; } = "Acol balanced rebid";
-    public override int Priority { get; } = 25;
+    public override int Priority { get; }
+
+    public AcolRebidBalanced(int priority = 25)
+    {
+        Priority = priority;
+    }
+
     private int MinHcp1NTRebid { get; } = 15;
     private int MaxHcp1NTRebid { get; } = 17;
     private int MinHcp2NTRebid { get; } = 18;

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidNewSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidNewSuit.cs
@@ -9,7 +9,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolRebidNewSuit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol rebid new suit";
-    public override int Priority { get; } = 40;
+    public override int Priority { get; }
+
+    public AcolRebidNewSuit(int priority = 40)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidOwnSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidOwnSuit.cs
@@ -9,7 +9,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolRebidOwnSuit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol rebid own suit";
-    public override int Priority { get; } = 42;
+    public override int Priority { get; }
+
+    public AcolRebidOwnSuit(int priority = 42)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidRaiseSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/OpenerRebid/AcolRebidRaiseSuit.cs
@@ -9,7 +9,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 public class AcolRebidRaiseSuit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol rebid partner's suit";
-    public override int Priority { get; } = 35;
+    public override int Priority { get; }
+
+    public AcolRebidRaiseSuit(int priority = 35)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol1NTOpeningRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol1NTOpeningRule.cs
@@ -8,13 +8,22 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Openings;
 public class Acol1NTOpeningRule : BiddingRuleBase
 {
     public override string Name { get; } = "Acol 1NT Opening";
-    public override int Priority { get; } = 20;
+    public override int Priority { get; }
 
-    private const int MinHcp = 12;
-    private const int MaxHcp = 14;
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _level;
 
-    private static CompositeConstraint BuildConstraints()
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp), new BalancedConstraint() } };
+    public Acol1NTOpeningRule(int minHcp = 12, int maxHcp = 14, int level = 1, int priority = 20)
+    {
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _level = level;
+        Priority = priority;
+    }
+
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new BalancedConstraint() } };
 
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => BuildConstraints();
@@ -23,14 +32,14 @@ public class Acol1NTOpeningRule : BiddingRuleBase
         => auction.SeatRoleType == SeatRoleType.NoBids;
 
     protected override bool IsHandApplicable(DecisionContext ctx)
-        => ctx.HandEvaluation.Hcp is >= MinHcp and <= MaxHcp
+        => ctx.HandEvaluation.Hcp >= _minHcp && ctx.HandEvaluation.Hcp <= _maxHcp
            && ctx.HandEvaluation.IsBalanced;
 
     public override Bid? Apply(DecisionContext ctx)
-        => Bid.NoTrumpsBid(1);
+        => Bid.NoTrumpsBid(_level);
 
     protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
-        => bid is { Type: BidType.NoTrumps, Level: 1 };
+        => bid.Type == BidType.NoTrumps && bid.Level == _level;
 
     public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
         => new(bid, BuildConstraints(), PartnershipBiddingState.ConstructiveSearch);

--- a/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol1SuitOpeningRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol1SuitOpeningRule.cs
@@ -9,19 +9,28 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Openings;
 public class Acol1SuitOpeningRule : BiddingRuleBase
 {
     public override string Name { get; } = "Acol 1-Level Suit Opening";
-    public override int Priority { get; } = 10;
+    public override int Priority { get; }
 
-    private const int MinHcp = 12;
-    private const int MaxHcp = 19;
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _minSuitLength;
+
+    public Acol1SuitOpeningRule(int minHcp = 12, int maxHcp = 19, int minSuitLength = 4, int priority = 10)
+    {
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _minSuitLength = minSuitLength;
+        Priority = priority;
+    }
 
     // Forward: the full conjunction of what must be true for this rule to fire.
     // We can't include a suit constraint here because we don't know which suit yet.
-    private static CompositeConstraint BuildConstraints()
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp) } };
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp) } };
 
     // Backward: once we know which suit was bid, we can add the suit length.
-    private static CompositeConstraint BuildConstraints(Suit? suit)
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp), new SuitLengthConstraint(suit.ToString()!, ">=4") } };
+    private CompositeConstraint BuildConstraints(Suit? suit)
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint(suit.ToString()!, $">={_minSuitLength}") } };
 
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => BuildConstraints();
@@ -30,7 +39,7 @@ public class Acol1SuitOpeningRule : BiddingRuleBase
         => auction.SeatRoleType == SeatRoleType.NoBids;
 
     protected override bool IsHandApplicable(DecisionContext ctx)
-        => ctx.HandEvaluation.Hcp is >= MinHcp and <= MaxHcp;
+        => ctx.HandEvaluation.Hcp >= _minHcp && ctx.HandEvaluation.Hcp <= _maxHcp;
 
     public override Bid? Apply(DecisionContext ctx)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol2NTOpeningRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Openings/Acol2NTOpeningRule.cs
@@ -8,13 +8,22 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Openings;
 public class Acol2NTOpeningRule : BiddingRuleBase
 {
     public override string Name { get; } = "Acol 2NT Opening";
-    public override int Priority { get; } = 20;
+    public override int Priority { get; }
 
-    private const int MinHcp = 20;
-    private const int MaxHcp = 22;
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _level;
 
-    private static CompositeConstraint BuildConstraints()
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp), new BalancedConstraint() } };
+    public Acol2NTOpeningRule(int minHcp = 20, int maxHcp = 22, int level = 2, int priority = 20)
+    {
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _level = level;
+        Priority = priority;
+    }
+
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new BalancedConstraint() } };
 
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => BuildConstraints();
@@ -23,14 +32,14 @@ public class Acol2NTOpeningRule : BiddingRuleBase
         => auction.SeatRoleType == SeatRoleType.NoBids;
 
     protected override bool IsHandApplicable(DecisionContext ctx)
-        => ctx.HandEvaluation.Hcp is >= MinHcp and <= MaxHcp
+        => ctx.HandEvaluation.Hcp >= _minHcp && ctx.HandEvaluation.Hcp <= _maxHcp
            && ctx.HandEvaluation.IsBalanced;
 
     public override Bid? Apply(DecisionContext ctx)
-        => Bid.NoTrumpsBid(2);
+        => Bid.NoTrumpsBid(_level);
 
     protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
-        => bid.Type == BidType.NoTrumps && bid.Level == 2;
+        => bid.Type == BidType.NoTrumps && bid.Level == _level;
 
     public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
         => new(bid, BuildConstraints(), PartnershipBiddingState.ConstructiveSearch);

--- a/BridgeIt.Core/BiddingEngine/Rules/Openings/AcolStrongOpening.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Openings/AcolStrongOpening.cs
@@ -9,15 +9,28 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Openings;
 public class AcolStrongOpening : BiddingRuleBase
 {
     public override string Name { get; } = "Acol Strong Opening";
-    public override int Priority { get; } = 19;
+    public override int Priority { get; }
     public override bool IsAlertable => true;
 
-    private const int MinHcpUnbalanced = 20;
-    private const int MinHcpBalanced = 23;
-    private const int MaxHcp = 35;
+    private readonly int _minHcpUnbalanced;
+    private readonly int _minHcpBalanced;
+    private readonly int _maxHcp;
+    private readonly int _bidLevel;
+    private readonly Suit _bidSuit;
 
-    private static CompositeConstraint BuildConstraints()
-        => new() { Constraints = { new HcpConstraint(MinHcpUnbalanced, MaxHcp) } };
+    public AcolStrongOpening(int minHcpUnbalanced = 20, int minHcpBalanced = 23, int maxHcp = 35,
+        int bidLevel = 2, Suit bidSuit = Suit.Clubs, int priority = 19)
+    {
+        _minHcpUnbalanced = minHcpUnbalanced;
+        _minHcpBalanced = minHcpBalanced;
+        _maxHcp = maxHcp;
+        _bidLevel = bidLevel;
+        _bidSuit = bidSuit;
+        Priority = priority;
+    }
+
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcpUnbalanced, _maxHcp) } };
 
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => BuildConstraints();
@@ -28,20 +41,19 @@ public class AcolStrongOpening : BiddingRuleBase
     protected override bool IsHandApplicable(DecisionContext ctx)
     {
         var hcp = ctx.HandEvaluation.Hcp;
-        if (hcp > MaxHcp) return false;
+        if (hcp > _maxHcp) return false;
 
-        // 23+ balanced or 20+ unbalanced
         if (ctx.HandEvaluation.IsBalanced)
-            return hcp >= MinHcpBalanced;
+            return hcp >= _minHcpBalanced;
 
-        return hcp >= MinHcpUnbalanced;
+        return hcp >= _minHcpUnbalanced;
     }
 
     public override Bid? Apply(DecisionContext ctx)
-        => Bid.SuitBid(2, Suit.Clubs);
+        => Bid.SuitBid(_bidLevel, _bidSuit);
 
     protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
-        => bid is { Type: BidType.Suit, Level: 2, Suit: Suit.Clubs };
+        => bid.Type == BidType.Suit && bid.Level == _bidLevel && bid.Suit == _bidSuit;
 
     public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
         => new(bid, BuildConstraints(), PartnershipBiddingState.ConstructiveSearch);

--- a/BridgeIt.Core/BiddingEngine/Rules/Openings/WeakOpeningRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Openings/WeakOpeningRule.cs
@@ -9,25 +9,32 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Openings;
 public class WeakOpeningRule : BiddingRuleBase
 {
     public override string Name { get; } = "Weak Opening";
-    public override int Priority { get; } = 9;
-    private const int Number = 4;
-    private const int MinHcp = 6;
-    private const int MaxHcp = 9;
+    public override int Priority { get; }
+    private readonly int _number;
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _minSuitLength;
 
     private readonly HashSet<Bid> _reservedBids;
     private readonly List<IBidConstraint> _constraints;
 
     // Forward: what must be true for any weak opening to fire
-    private static CompositeConstraint BuildConstraints()
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp), new SuitLengthConstraint("any", ">=6") } };
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint("any", $">={_minSuitLength}") } };
 
     // Backward: once we know the specific bid, we know the exact suit and length
-    private static CompositeConstraint BuildConstraints(Bid bid)
-        => new() { Constraints = { new HcpConstraint(MinHcp, MaxHcp), new SuitLengthConstraint(bid.Suit!.Value, bid.Level + Number, bid.Level + Number) } };
+    private CompositeConstraint BuildConstraints(Bid bid)
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint(bid.Suit!.Value, bid.Level + _number, bid.Level + _number) } };
 
-    public WeakOpeningRule(IEnumerable<Bid> reservedBids)
+    public WeakOpeningRule(IEnumerable<Bid> reservedBids, int minHcp = 6, int maxHcp = 9,
+        int minSuitLength = 6, int number = 4, int priority = 9)
     {
-        _constraints = [new HcpConstraint(MinHcp, MaxHcp), new SuitLengthConstraint("any", ">=6")];
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _minSuitLength = minSuitLength;
+        _number = number;
+        Priority = priority;
+        _constraints = [new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint("any", $">={_minSuitLength}")];
         _reservedBids = reservedBids.ToHashSet();
     }
 
@@ -59,6 +66,6 @@ public class WeakOpeningRule : BiddingRuleBase
     {
         var suit = ctx.HandEvaluation.LongestAndStrongest;
         var level = ctx.HandEvaluation.Shape[suit];
-        return Bid.SuitBid(level - Number, suit);
+        return Bid.SuitBid(level - _number, suit);
     }
 }

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/AcolResponseTo2C.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/AcolResponseTo2C.cs
@@ -8,9 +8,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder;
 public class AcolResponseTo2C : BiddingRuleBase
 {
     public override string Name { get; } = "Acol response to 2C";
-    public override int Priority { get; } = 50;
+    public override int Priority { get; }
     public override bool IsAlertable => true;
 
+    public AcolResponseTo2C(int priority = 50)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpener1NTRebid.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpener1NTRebid.cs
@@ -26,7 +26,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 public class AcolResponderAfterOpener1NTRebid : BiddingRuleBase
 {
     public override string Name => "Acol responder after opener 1NT rebid";
-    public override int Priority => 50;
+    public override int Priority { get; }
+
+    public AcolResponderAfterOpener1NTRebid(int priority = 50)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpener2NTRebid.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpener2NTRebid.cs
@@ -22,7 +22,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 public class AcolResponderAfterOpener2NTRebid : BiddingRuleBase
 {
     public override string Name => "Acol responder after opener 2NT rebid";
-    public override int Priority => 50;
+    public override int Priority { get; }
+
+    public AcolResponderAfterOpener2NTRebid(int priority = 50)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerNewSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerNewSuit.cs
@@ -27,7 +27,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 public class AcolResponderAfterOpenerNewSuit : BiddingRuleBase
 {
     public override string Name => "Acol responder after opener new suit";
-    public override int Priority => 45;
+    public override int Priority { get; }
+
+    public AcolResponderAfterOpenerNewSuit(int priority = 45)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerRaisedSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerRaisedSuit.cs
@@ -30,7 +30,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 public class AcolResponderAfterOpenerRaisedSuit : BiddingRuleBase
 {
     public override string Name => "Acol responder after opener raised suit";
-    public override int Priority => 52;
+    public override int Priority { get; }
+
+    public AcolResponderAfterOpenerRaisedSuit(int priority = 52)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerRebidOwnSuit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponderRebids/AcolResponderAfterOpenerRebidOwnSuit.cs
@@ -27,7 +27,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 public class AcolResponderAfterOpenerRebidOwnSuit : BiddingRuleBase
 {
     public override string Name => "Acol responder after opener rebid own suit";
-    public override int Priority => 48;
+    public override int Priority { get; }
+
+    public AcolResponderAfterOpenerRebidOwnSuit(int priority = 48)
+    {
+        Priority = priority;
+    }
 
     protected override bool IsApplicableContext(AuctionEvaluation auction)
     {

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1NT/AcolNTRaiseOver1NT.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1NT/AcolNTRaiseOver1NT.cs
@@ -18,7 +18,12 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1NT;
 public class AcolNTRaiseOver1NT : BiddingRuleBase
 {
     public override string Name { get; } = "NT Raise over 1NT";
-    public override int Priority { get; } = 15;
+    public override int Priority { get; }
+
+    public AcolNTRaiseOver1NT(int priority = 15)
+    {
+        Priority = priority;
+    }
 
     private Bid ApplicableOpeningBid => Bid.NoTrumpsBid(1);
 

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/Acol1NTResponseTo1Suit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/Acol1NTResponseTo1Suit.cs
@@ -8,7 +8,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 public class Acol1NTResponseTo1Suit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol 1NT response to 1 suit";
-    public override int Priority { get; } = 30;
+    public override int Priority { get; }
+
+    public Acol1NTResponseTo1Suit(int priority = 30)
+    {
+        Priority = priority;
+    }
+
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => new() { Constraints = { new HcpConstraint(6, 40) } };
 

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolJacoby2NTOver1Major.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolJacoby2NTOver1Major.cs
@@ -9,8 +9,14 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 public class AcolJacoby2NTOver1Major :  BiddingRuleBase
 {
     public override string Name { get; } = "Acol Jacoby 2NT over 1 major";
-    public override int Priority { get; } = 55;
+    public override int Priority { get; }
     public override bool IsAlertable => true;
+
+    public AcolJacoby2NTOver1Major(int priority = 55)
+    {
+        Priority = priority;
+    }
+
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
     {
         var suit = auction.OpeningBid?.Suit;

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolNewSuitOver1Suit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolNewSuitOver1Suit.cs
@@ -9,7 +9,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 public class AcolNewSuitOver1Suit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol new suit over 1 suit";
-    public override int Priority { get; } = 40;
+    public override int Priority { get; }
+
+    public AcolNewSuitOver1Suit(int priority = 40)
+    {
+        Priority = priority;
+    }
+
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
         => new() { Constraints = { new HcpConstraint(6, 40) } };
 

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMajorOver1Suit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMajorOver1Suit.cs
@@ -9,7 +9,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 public class AcolRaiseMajorOver1Suit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol raise major over 1 suit";
-    public override int Priority { get; } = 50;
+    public override int Priority { get; }
+
+    public AcolRaiseMajorOver1Suit(int priority = 50)
+    {
+        Priority = priority;
+    }
+
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
     {
         var suit = auction.OpeningBid?.Suit;

--- a/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMinorOver1Suit.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMinorOver1Suit.cs
@@ -9,7 +9,13 @@ namespace BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 public class AcolRaiseMinorOver1Suit : BiddingRuleBase
 {
     public override string Name { get; } = "Acol raise minor over 1 suit";
-    public override int Priority { get; } = 35;
+    public override int Priority { get; }
+
+    public AcolRaiseMinorOver1Suit(int priority = 35)
+    {
+        Priority = priority;
+    }
+
     public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
     {
         var suit = auction.OpeningBid?.Suit;

--- a/BridgeIt.Systems/BiddingSystemLoader.cs
+++ b/BridgeIt.Systems/BiddingSystemLoader.cs
@@ -1,0 +1,327 @@
+using System.Text.Json;
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Conventions;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Knowledge;
+using BridgeIt.Core.BiddingEngine.Rules.Openings;
+using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
+using BridgeIt.Core.BiddingEngine.Rules.Responder;
+using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1NT;
+using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
+using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Systems.Config;
+using Microsoft.Extensions.Logging;
+
+namespace BridgeIt.Systems;
+
+/// <summary>
+/// Loads a bidding system from a <see cref="BridgeSystemConfig"/>, instantiating
+/// rule classes with the correct parameters and priorities.
+///
+/// Config sections without corresponding rule implementations are logged as warnings
+/// and skipped. This allows the JSON files to be fully specified from day 1.
+/// </summary>
+public class BiddingSystemLoader
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+
+    private readonly ILogger<BiddingSystemLoader>? _logger;
+
+    public BiddingSystemLoader(ILogger<BiddingSystemLoader>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    public LoadedSystem LoadFromFile(string path)
+    {
+        var json = File.ReadAllText(path);
+        return LoadFromJson(json);
+    }
+
+    public LoadedSystem LoadFromJson(string json)
+    {
+        var config = JsonSerializer.Deserialize<BridgeSystemConfig>(json, JsonOpts)
+                     ?? throw new InvalidOperationException("Failed to deserialise system config JSON");
+        return Load(config);
+    }
+
+    public LoadedSystem Load(BridgeSystemConfig config)
+    {
+        var rules = new List<IBiddingRule>();
+        var warnings = new List<string>();
+        var priorities = config.Priorities ?? new Dictionary<string, int>();
+
+        // ── Opening rules ──────────────────────────────────────────────
+        if (config.NT1Opening is { } nt1)
+        {
+            rules.Add(new Acol1NTOpeningRule(
+                nt1.MinHcp, nt1.MaxHcp, nt1.Level,
+                GetPriority(priorities, "Acol1NTOpening", 20)));
+        }
+
+        if (config.NT2Opening is { } nt2)
+        {
+            rules.Add(new Acol2NTOpeningRule(
+                nt2.MinHcp, nt2.MaxHcp, nt2.Level,
+                GetPriority(priorities, "Acol2NTOpening", 20)));
+        }
+
+        if (config.SuitOpening is { } suit)
+        {
+            rules.Add(new Acol1SuitOpeningRule(
+                suit.MinHcp, suit.MaxHcp, suit.MajorMinLength,
+                GetPriority(priorities, "Acol1SuitOpening", 10)));
+        }
+
+        if (config.StrongOpening is { } strong)
+        {
+            var strongBid = ParseBid(strong.Bid);
+            rules.Add(new AcolStrongOpening(
+                strong.MinHcpUnbalanced, strong.MinHcpBalanced, strong.MaxHcp,
+                strongBid?.Level ?? 2, strongBid?.Suit ?? Suit.Clubs,
+                GetPriority(priorities, "AcolStrongOpening", 19)));
+        }
+
+        if (config.Preempts is { } preempts)
+        {
+            var reservedBids = (preempts.ReservedBids ?? new List<string>())
+                .Select(ParseBid)
+                .Where(b => b is not null)
+                .Cast<Bid>()
+                .ToArray();
+            rules.Add(new WeakOpeningRule(
+                reservedBids, preempts.MinHcp, preempts.MaxHcp,
+                preempts.MinSuitLength3Level - 1, // minSuitLength for any preempt
+                priority: GetPriority(priorities, "WeakOpening", 9)));
+        }
+
+        // ── NT Convention contexts ─────────────────────────────────────
+        // Build NTConventionContexts from config for use by convention rules
+        NTConventionContext? after1NT = null;
+        NTConventionContext? after2NT = null;
+        NTConventionContext? after2C2D2NT = null;
+
+        if (config.NT1Opening is not null && config.ResponseTo1NT is not null)
+        {
+            var staymanMinHcp = config.ResponseTo1NT.Stayman?.MinHcp ?? 11;
+            after1NT = new NTConventionContext
+            {
+                Name = "1NT",
+                ConventionLevel = 2,
+                StaymanHcpMin = staymanMinHcp,
+                ResponderIsTriggered = a =>
+                    a.BiddingRound == 1
+                    && a.PartnerLastNonPassBid == Bid.NoTrumpsBid(1)
+                    && a.OpeningBid == Bid.NoTrumpsBid(1)
+            };
+        }
+
+        if (config.NT2Opening is not null && config.ResponseTo2NT is not null)
+        {
+            var staymanMinHcp = config.ResponseTo2NT.Stayman?.MinHcp ?? 4;
+            after2NT = new NTConventionContext
+            {
+                Name = "2NT",
+                ConventionLevel = 3,
+                StaymanHcpMin = staymanMinHcp,
+                ResponderIsTriggered = a =>
+                    a.BiddingRound == 1
+                    && a.PartnerLastNonPassBid == Bid.NoTrumpsBid(2)
+                    && a.OpeningBid == Bid.NoTrumpsBid(2)
+            };
+        }
+
+        // After 2C-2D-2NT sequence (strong opening → 2D response → 2NT rebid)
+        if (config.StrongOpening is not null && config.NT2Opening is not null)
+        {
+            after2C2D2NT = new NTConventionContext
+            {
+                Name = "2C-2D-2NT",
+                ConventionLevel = 3,
+                StaymanHcpMin = 0,
+                ResponderIsTriggered = a =>
+                    a.BiddingRound == 2
+                    && a.PartnerLastNonPassBid == Bid.NoTrumpsBid(2)
+                    && a.OpeningBid == Bid.SuitBid(2, Suit.Clubs)
+            };
+        }
+
+        // ── Convention rules (responses to NT) ─────────────────────────
+        AddNTConventionRules(rules, config.ResponseTo1NT, after1NT, "1NT", priorities);
+        AddNTConventionRules(rules, config.ResponseTo2NT, after2NT, "2NT", priorities);
+
+        // 2C-2D-2NT conventions (Stayman/Transfer after strong opening sequence)
+        if (after2C2D2NT is not null)
+        {
+            AddNTConventionRules(rules, config.ResponseTo2NT, after2C2D2NT, "2C2D2NT", priorities);
+        }
+
+        // ── Response to 1NT: NT raise ──────────────────────────────────
+        if (config.ResponseTo1NT?.Raise is { Enabled: true })
+        {
+            rules.Add(new AcolNTRaiseOver1NT());
+        }
+
+        // ── Response to 2C ─────────────────────────────────────────────
+        if (config.ResponseTo2C is { Enabled: true })
+        {
+            rules.Add(new AcolResponseTo2C());
+        }
+
+        // ── Responses to 1-suit ────────────────────────────────────────
+        if (config.ResponseTo1Suit is not null)
+        {
+            rules.Add(new AcolJacoby2NTOver1Major());
+            rules.Add(new AcolRaiseMajorOver1Suit());
+            rules.Add(new AcolRaiseMinorOver1Suit());
+            rules.Add(new AcolNewSuitOver1Suit());
+            rules.Add(new Acol1NTResponseTo1Suit());
+        }
+
+        // ── Opener rebids ──────────────────────────────────────────────
+        if (config.OpenerRebid is not null)
+        {
+            rules.Add(new AcolOpenerRebidAfter2C());
+
+            // Stayman responses (opener side)
+            if (after1NT is not null)
+            {
+                rules.Add(new StaymanResponse(after1NT, GetPriority(priorities, "StaymanResponse_1NT", 60)));
+                rules.Add(new AcolResponderAfterStayman(after1NT));
+            }
+            if (after2NT is not null)
+            {
+                rules.Add(new StaymanResponse(after2NT, GetPriority(priorities, "StaymanResponse_2NT", 60)));
+                rules.Add(new AcolResponderAfterStayman(after2NT));
+            }
+            if (after2C2D2NT is not null)
+            {
+                rules.Add(new StaymanResponse(after2C2D2NT, GetPriority(priorities, "StaymanResponse_2C2D2NT", 60)));
+                rules.Add(new AcolResponderAfterStayman(after2C2D2NT));
+            }
+
+            // Transfer completion (opener side)
+            if (after1NT is not null && config.ResponseTo1NT?.Transfers is { Enabled: true })
+                rules.Add(new CompleteTransfer(after1NT, GetPriority(priorities, "CompleteTransfer_1NT", 30)));
+            if (after2NT is not null && config.ResponseTo2NT?.Transfers is { Enabled: true })
+                rules.Add(new CompleteTransfer(after2NT, GetPriority(priorities, "CompleteTransfer_2NT", 30)));
+            if (after2C2D2NT is not null)
+                rules.Add(new CompleteTransfer(after2C2D2NT, GetPriority(priorities, "CompleteTransfer_2C2D2NT", 30)));
+
+            rules.Add(new AcolOpenerAfterNTInvite());
+            rules.Add(new AcolOpenerAfterMajorRaise());
+            rules.Add(new AcolRebidBalanced());
+            rules.Add(new AcolRebidNewSuit());
+            rules.Add(new AcolRebidRaiseSuit());
+            rules.Add(new AcolRebidOwnSuit());
+        }
+
+        // ── Responder rebids ───────────────────────────────────────────
+        if (config.ResponderRebid is not null)
+        {
+            rules.Add(new AcolResponderAfterOpenerRaisedSuit());
+            rules.Add(new AcolResponderAfterOpener1NTRebid());
+            rules.Add(new AcolResponderAfterOpener2NTRebid());
+            rules.Add(new AcolResponderAfterOpenerRebidOwnSuit());
+            rules.Add(new AcolResponderAfterOpenerNewSuit());
+        }
+
+        // ── Knowledge catch-all rules (always included) ────────────────
+        rules.Add(new KnowledgeBidGameInSuit());
+        rules.Add(new KnowledgeBidGameInNT());
+        rules.Add(new KnowledgeInviteInSuit());
+        rules.Add(new KnowledgeInviteInNT());
+        rules.Add(new KnowledgeSignOffInFit());
+        rules.Add(new KnowledgeSignOff());
+
+        // ── Warn about unbuilt sections ────────────────────────────────
+        WarnIfPresent(config.Overcalls, "Overcalls", warnings);
+        WarnIfPresent(config.NegativeDoubles, "NegativeDoubles", warnings);
+        WarnIfPresent(config.CompetitiveAuctions, "CompetitiveAuctions", warnings);
+        WarnIfPresent(config.Slam, "Slam", warnings);
+        WarnIfPresent(config.FourthSuitForcing, "FourthSuitForcing", warnings);
+        WarnIfPresent(config.Splinters, "Splinters", warnings);
+        WarnIfPresent(config.TrialBids, "TrialBids", warnings);
+
+        if (config.TwoLevelOpenings?.BenjaminTwos == true)
+            warnings.Add("BenjaminTwos: no rule implementation yet — skipped");
+        if (config.TwoLevelOpenings?.WeakTwos is not null)
+            warnings.Add("WeakTwos: no dedicated rule implementation yet — skipped (preempts cover some cases)");
+        if (config.TwoLevelOpenings?.AcolTwos is not null)
+            warnings.Add("AcolTwos: no rule implementation yet — skipped");
+        if (config.ResponseTo1NT?.WeaknessTakeouts is { Enabled: true })
+            warnings.Add("WeaknessTakeouts: no rule implementation yet — skipped");
+        if (config.ResponseTo1NT?.MinorTransfers is { Enabled: true })
+            warnings.Add("MinorTransfers: no rule implementation yet — skipped");
+        if (config.ResponseTo1NT?.Baron is { Enabled: true })
+            warnings.Add("Baron: no rule implementation yet — skipped");
+        if (config.ResponseTo2NT?.Baron is { Enabled: true })
+            warnings.Add("Baron (2NT): no rule implementation yet — skipped");
+
+        foreach (var warning in warnings)
+            _logger?.LogWarning("SystemLoader: {Warning}", warning);
+
+        // Sort by priority descending
+        var sorted = rules.OrderByDescending(r => r.Priority).ToList();
+
+        return new LoadedSystem(config.Name, sorted, config, warnings);
+    }
+
+    private static void AddNTConventionRules(
+        List<IBiddingRule> rules,
+        NTResponseConfig? responseConfig,
+        NTConventionContext? ctx,
+        string suffix,
+        Dictionary<string, int> priorities)
+    {
+        if (responseConfig is null || ctx is null) return;
+
+        if (responseConfig.Stayman is { Enabled: true })
+        {
+            rules.Add(new StandardStayman(ctx, GetPriority(priorities, $"StandardStayman_{suffix}", 29)));
+        }
+
+        if (responseConfig.Transfers is { Enabled: true })
+        {
+            rules.Add(new StandardTransfer(ctx, GetPriority(priorities, $"StandardTransfer_{suffix}", 30)));
+        }
+    }
+
+    private static int GetPriority(Dictionary<string, int> priorities, string ruleName, int defaultPriority)
+    {
+        return priorities.TryGetValue(ruleName, out var p) ? p : defaultPriority;
+    }
+
+    private static void WarnIfPresent(object? config, string name, List<string> warnings)
+    {
+        if (config is not null)
+            warnings.Add($"{name}: no rule implementation yet — skipped");
+    }
+
+    private static Bid? ParseBid(string bidStr)
+    {
+        if (string.IsNullOrWhiteSpace(bidStr)) return null;
+        // Simple parsing for common bid formats like "2C", "3H", etc.
+        if (bidStr.Length < 2) return null;
+
+        if (!int.TryParse(bidStr[0].ToString(), out var level)) return null;
+
+        var suitChar = char.ToUpper(bidStr[1]);
+        Suit? suit = suitChar switch
+        {
+            'C' => Suit.Clubs,
+            'D' => Suit.Diamonds,
+            'H' => Suit.Hearts,
+            'S' => Suit.Spades,
+            _ => null
+        };
+
+        return suit.HasValue ? Bid.SuitBid(level, suit.Value) : null;
+    }
+}

--- a/BridgeIt.Systems/BridgeIt.Systems.csproj
+++ b/BridgeIt.Systems/BridgeIt.Systems.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\BridgeIt.Core\BridgeIt.Core.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/BridgeIt.Systems/Class1.cs
+++ b/BridgeIt.Systems/Class1.cs
@@ -1,5 +1,0 @@
-﻿namespace BridgeIt.Systems;
-
-public class Class1
-{
-}

--- a/BridgeIt.Systems/Config/BridgeSystemConfig.cs
+++ b/BridgeIt.Systems/Config/BridgeSystemConfig.cs
@@ -1,0 +1,49 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Top-level configuration for a complete bidding system.
+/// Mirrors the sections of an EBU convention card.
+/// Nullable sections mean "not configured / no rules for this area".
+/// The loader skips sections that don't have corresponding rule implementations.
+/// </summary>
+public record BridgeSystemConfig
+{
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+
+    // Opening bids
+    public NTOpeningConfig? NT1Opening { get; init; }
+    public NTOpeningConfig? NT2Opening { get; init; }
+    public SuitOpeningConfig? SuitOpening { get; init; }
+    public StrongOpeningConfig? StrongOpening { get; init; }
+    public PreemptConfig? Preempts { get; init; }
+    public TwoLevelOpeningConfig? TwoLevelOpenings { get; init; }
+
+    // Responses to NT openings
+    public NTResponseConfig? ResponseTo1NT { get; init; }
+    public NTResponseConfig? ResponseTo2NT { get; init; }
+
+    // Responses to suit openings
+    public ResponseTo1SuitConfig? ResponseTo1Suit { get; init; }
+    public ResponseTo2CConfig? ResponseTo2C { get; init; }
+
+    // Rebids
+    public OpenerRebidConfig? OpenerRebid { get; init; }
+    public ResponderRebidConfig? ResponderRebid { get; init; }
+
+    // Competitive bidding (unbuilt — loader will skip)
+    public OvercallConfig? Overcalls { get; init; }
+    public NegativeDoubleConfig? NegativeDoubles { get; init; }
+    public CompetitiveAuctionConfig? CompetitiveAuctions { get; init; }
+
+    // Slam (unbuilt — loader will skip)
+    public SlamConfig? Slam { get; init; }
+
+    // Convention toggles
+    public FourthSuitForcingConfig? FourthSuitForcing { get; init; }
+    public SplinterConfig? Splinters { get; init; }
+    public TrialBidConfig? TrialBids { get; init; }
+
+    // Rule priorities — flat map of rule-name → priority
+    public Dictionary<string, int>? Priorities { get; init; }
+}

--- a/BridgeIt.Systems/Config/CompetitiveConfigs.cs
+++ b/BridgeIt.Systems/Config/CompetitiveConfigs.cs
@@ -1,0 +1,94 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Configuration for overcalls. Unbuilt — loader will skip.
+/// </summary>
+public record OvercallConfig
+{
+    public SimpleOvercallConfig? Simple { get; init; }
+    public JumpOvercallConfig? Jump { get; init; }
+    public CueBidOvercallConfig? CueBid { get; init; }
+    public NTOvercallConfig? NT1 { get; init; }
+    public UnusualNTConfig? Unusual2NT { get; init; }
+}
+
+public record SimpleOvercallConfig
+{
+    public int MinHcp { get; init; }
+}
+
+/// <summary>
+/// Jump overcall configuration.
+/// Foundation/L2: Intermediate (12-16, good 6-card suit).
+/// Benji: Weak (usually 6-card suit).
+/// </summary>
+public record JumpOvercallConfig
+{
+    /// <summary>"Intermediate" or "Weak".</summary>
+    public string Style { get; init; } = "Intermediate";
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+    public int MinSuitLength { get; init; }
+}
+
+/// <summary>
+/// Cue bid overcall configuration (Michaels).
+/// </summary>
+public record CueBidOvercallConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>"Michaels" or other style name.</summary>
+    public string Style { get; init; } = "Michaels";
+    public int MinSuitLength { get; init; }
+}
+
+/// <summary>
+/// 1NT overcall configuration.
+/// </summary>
+public record NTOvercallConfig
+{
+    public int DirectMinHcp { get; init; }
+    public int DirectMaxHcp { get; init; }
+    public int ProtectiveMinHcp { get; init; }
+    public int ProtectiveMaxHcp { get; init; }
+}
+
+/// <summary>
+/// Unusual 2NT overcall (shows two lowest unbid suits).
+/// </summary>
+public record UnusualNTConfig
+{
+    public bool Enabled { get; init; }
+}
+
+/// <summary>
+/// Negative double configuration.
+/// </summary>
+public record NegativeDoubleConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>Maximum level to which negative doubles apply. e.g. "2S" or "3S".</summary>
+    public string MaxLevel { get; init; } = "2S";
+}
+
+/// <summary>
+/// Competitive auction agreements.
+/// </summary>
+public record CompetitiveAuctionConfig
+{
+    public bool RedoubleShows9Plus { get; init; }
+    public bool NewSuitForcing { get; init; }
+    public bool JumpRaisePreemptive { get; init; }
+    public bool TwoNTGoodRaise { get; init; }
+    public UnassumingCueBidConfig? UnassumingCueBids { get; init; }
+}
+
+/// <summary>
+/// Unassuming cue bid configuration (opposite partner's overcall, shows a good raise).
+/// </summary>
+public record UnassumingCueBidConfig
+{
+    public bool Enabled { get; init; }
+}

--- a/BridgeIt.Systems/Config/ConventionConfigs.cs
+++ b/BridgeIt.Systems/Config/ConventionConfigs.cs
@@ -1,0 +1,43 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Slam convention configuration.
+/// </summary>
+public record SlamConfig
+{
+    /// <summary>"Blackwood", "RKCB", or "None".</summary>
+    public string Style { get; init; } = "Blackwood";
+
+    /// <summary>Whether Grand Slam Force (5NT) is played.</summary>
+    public bool GrandSlamForce { get; init; }
+}
+
+/// <summary>
+/// Fourth Suit Forcing convention configuration.
+/// </summary>
+public record FourthSuitForcingConfig
+{
+    public bool Enabled { get; init; }
+}
+
+/// <summary>
+/// Splinter bid configuration.
+/// </summary>
+public record SplinterConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>Minimum trump support length for a splinter. Typically 4.</summary>
+    public int MinFitLength { get; init; }
+}
+
+/// <summary>
+/// Trial bid configuration (e.g. long suit trial bids after a simple raise).
+/// </summary>
+public record TrialBidConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>"LongSuit" or other style name.</summary>
+    public string Style { get; init; } = "LongSuit";
+}

--- a/BridgeIt.Systems/Config/NTResponseConfigs.cs
+++ b/BridgeIt.Systems/Config/NTResponseConfigs.cs
@@ -1,0 +1,102 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Configuration for responses to an NT opening (1NT or 2NT).
+/// Each sub-convention is nullable — null means not played.
+/// </summary>
+public record NTResponseConfig
+{
+    public StaymanConfig? Stayman { get; init; }
+    public TransferConfig? Transfers { get; init; }
+    public MinorTransferConfig? MinorTransfers { get; init; }
+    public BaronConfig? Baron { get; init; }
+    public WeaknessTakeoutConfig? WeaknessTakeouts { get; init; }
+    public NTRaiseConfig? Raise { get; init; }
+    public Jacoby2NTConfig? Jacoby2NT { get; init; }
+
+    /// <summary>After opponents double: all 2-level responses become natural.</summary>
+    public bool NaturalAfterDouble { get; init; }
+}
+
+/// <summary>
+/// Stayman convention configuration.
+/// </summary>
+public record StaymanConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>Minimum HCP to use Stayman. 11 after 1NT, 4 after 2NT, 0 after 2C-2D-2NT.</summary>
+    public int MinHcp { get; init; }
+}
+
+/// <summary>
+/// Jacoby transfer configuration (major suits only).
+/// </summary>
+public record TransferConfig
+{
+    public bool Enabled { get; init; }
+    public int MinSuitLength { get; init; }
+    public int MaxSuitLength { get; init; }
+}
+
+/// <summary>
+/// Minor suit transfer configuration.
+/// Benji: 2S transfers to clubs, 2NT transfers to diamonds.
+/// Level 2: 2NT relays to 3C (pass or correct to 3D).
+/// </summary>
+public record MinorTransferConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>Bid that transfers to clubs. e.g. "2S" (Benji after 1NT).</summary>
+    public string? ClubTransferBid { get; init; }
+
+    /// <summary>Bid that transfers to diamonds. e.g. "2NT" (Benji after 1NT).</summary>
+    public string? DiamondTransferBid { get; init; }
+}
+
+/// <summary>
+/// Baron convention configuration.
+/// Level 2: 2S over 1NT or 3S over 2NT — shows invitational or GF with slam interest.
+/// </summary>
+public record BaronConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>The bid used for Baron. "2S" after 1NT, "3S" after 2NT.</summary>
+    public string? Bid { get; init; }
+
+    public int InviteMinHcp { get; init; }
+    public int InviteMaxHcp { get; init; }
+}
+
+/// <summary>
+/// Weakness takeout configuration (Foundation Acol: 2D/2H/2S are drop-dead bids, no transfer meaning).
+/// </summary>
+public record WeaknessTakeoutConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>Bids that are weakness takeouts. e.g. ["2D","2H","2S"].</summary>
+    public List<string> Bids { get; init; } = new();
+}
+
+/// <summary>
+/// NT raise configuration (invitational raise).
+/// </summary>
+public record NTRaiseConfig
+{
+    public bool Enabled { get; init; }
+    public int InviteMinHcp { get; init; }
+    public int InviteMaxHcp { get; init; }
+}
+
+/// <summary>
+/// Jacoby 2NT convention (game-forcing raise of partner's major).
+/// </summary>
+public record Jacoby2NTConfig
+{
+    public bool Enabled { get; init; }
+    public int MinHcp { get; init; }
+    public int MinFitLength { get; init; }
+}

--- a/BridgeIt.Systems/Config/OpeningConfigs.cs
+++ b/BridgeIt.Systems/Config/OpeningConfigs.cs
@@ -1,0 +1,126 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Configuration for a no-trumps opening bid (1NT or 2NT).
+/// </summary>
+public record NTOpeningConfig
+{
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+    public int Level { get; init; }
+    public bool AllowSingleton { get; init; }
+}
+
+/// <summary>
+/// Configuration for 1-level suit openings.
+/// Handles both 4-card (Acol) and 5-card (SAYC) major systems.
+/// </summary>
+public record SuitOpeningConfig
+{
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+
+    /// <summary>Minimum length for a major suit opening. 4 for Acol, 5 for SAYC.</summary>
+    public int MajorMinLength { get; init; }
+
+    /// <summary>Minimum length for a minor suit opening. 4 for Acol, 3 for SAYC.</summary>
+    public int MinorMinLength { get; init; }
+
+    /// <summary>"HigherRanking" (Acol: open higher of equal-length suits) or "BetterMinor" (SAYC: open longer minor, 1C with 3-3).</summary>
+    public string MinorSelection { get; init; } = "HigherRanking";
+
+    /// <summary>Allow light opening if HCP + length of 2 longest suits >= 20.</summary>
+    public bool RuleOf20 { get; init; }
+
+    /// <summary>Acol 4-card major rules (4-4 major opening, 4441 hands). Null for 5-card major systems.</summary>
+    public FourCardMajorConfig? FourCardMajor { get; init; }
+}
+
+/// <summary>
+/// Acol-specific rules for opening with 4-card majors.
+/// </summary>
+public record FourCardMajorConfig
+{
+    /// <summary>With 4-4 in both majors, open this bid. "1H" for Acol.</summary>
+    public string? FourFourMajorOpening { get; init; }
+
+    /// <summary>4441 hand openings keyed by singleton suit. e.g. {"Clubs":"1H", "Diamonds":"1C", "Hearts":"1D", "Spades":"1D"}.</summary>
+    public Dictionary<string, string>? FourFourFourOneMap { get; init; }
+}
+
+/// <summary>
+/// Configuration for strong artificial opening (2C in most systems).
+/// </summary>
+public record StrongOpeningConfig
+{
+    public int MinHcpBalanced { get; init; }
+    public int MinHcpUnbalanced { get; init; }
+    public int MaxHcp { get; init; }
+
+    /// <summary>The bid used for the strong opening. "2C" for standard and Benji.</summary>
+    public string Bid { get; init; } = "2C";
+
+    /// <summary>True if game-forcing (standard 2C), false for Benji's Acol 2.</summary>
+    public bool GameForcing { get; init; }
+}
+
+/// <summary>
+/// Configuration for preemptive openings (3-level and 4-level).
+/// </summary>
+public record PreemptConfig
+{
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+
+    /// <summary>Minimum suit length for a 3-level preempt. 7 for Foundation/L2, 6 for Benji.</summary>
+    public int MinSuitLength3Level { get; init; }
+
+    /// <summary>Minimum suit length for a 4-level preempt. 8 for Foundation/L2, 7 for Benji.</summary>
+    public int MinSuitLength4Level { get; init; }
+
+    /// <summary>Bids reserved for other conventions (e.g. ["2C"] for strong opening). Preempts won't use these.</summary>
+    public List<string>? ReservedBids { get; init; }
+}
+
+/// <summary>
+/// Configuration for the 2-level opening area (highly variant across systems).
+/// </summary>
+public record TwoLevelOpeningConfig
+{
+    /// <summary>Benjamin system: 2C = Acol 2 (strong, not GF), 2D = GF. Swaps meaning of 2C/2D.</summary>
+    public bool BenjaminTwos { get; init; }
+
+    /// <summary>Weak two openings (2H, 2S, optionally 2D).</summary>
+    public WeakTwoConfig? WeakTwos { get; init; }
+
+    /// <summary>Acol strong twos (2D, 2H, 2S — strong but not game-forcing).</summary>
+    public AcolTwoConfig? AcolTwos { get; init; }
+}
+
+/// <summary>
+/// Configuration for weak two openings.
+/// </summary>
+public record WeakTwoConfig
+{
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+    public int MinSuitLength { get; init; }
+
+    /// <summary>Which suits can be opened as weak twos. e.g. ["H","S"] or ["D","H","S"].</summary>
+    public List<string> Suits { get; init; } = new();
+
+    /// <summary>Whether 2NT is used as a forcing enquiry (asking for a feature).</summary>
+    public bool TwoNTEnquiry { get; init; }
+}
+
+/// <summary>
+/// Configuration for Acol strong two openings (not game-forcing).
+/// </summary>
+public record AcolTwoConfig
+{
+    public int MinHcp { get; init; }
+    public int MaxHcp { get; init; }
+
+    /// <summary>Which suits can be opened as Acol twos. e.g. ["D","H","S"].</summary>
+    public List<string> Suits { get; init; } = new();
+}

--- a/BridgeIt.Systems/Config/RebidConfigs.cs
+++ b/BridgeIt.Systems/Config/RebidConfigs.cs
@@ -1,0 +1,33 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Configuration for opener's rebids.
+/// </summary>
+public record OpenerRebidConfig
+{
+    /// <summary>Minimum HCP for a reverse bid. Typically 16.</summary>
+    public int ReverseMinHcp { get; init; }
+
+    /// <summary>NT rebid HCP ranges after a 1-level response.</summary>
+    public NTRebidRangeConfig? NTRebid { get; init; }
+}
+
+/// <summary>
+/// HCP ranges for opener's NT rebids.
+/// Foundation/L2: 15-16 / 17-18 / 19.
+/// Benji: 15-17 / 18-19 / long suit.
+/// </summary>
+public record NTRebidRangeConfig
+{
+    public int Rebid1NTMin { get; init; }
+    public int Rebid1NTMax { get; init; }
+    public int Rebid2NTMin { get; init; }
+    public int Rebid2NTMax { get; init; }
+    public int Rebid3NTMin { get; init; }
+    public int Rebid3NTMax { get; init; }
+}
+
+/// <summary>
+/// Configuration for responder's rebids. Placeholder — expand as rules grow.
+/// </summary>
+public record ResponderRebidConfig;

--- a/BridgeIt.Systems/Config/ResponseConfigs.cs
+++ b/BridgeIt.Systems/Config/ResponseConfigs.cs
@@ -1,0 +1,42 @@
+namespace BridgeIt.Systems.Config;
+
+/// <summary>
+/// Configuration for responses to 1-level suit openings.
+/// </summary>
+public record ResponseTo1SuitConfig
+{
+    /// <summary>Minimum HCP for a new suit response at the 1-level. Typically 6.</summary>
+    public int MinHcpFor1Level { get; init; }
+
+    /// <summary>Minimum HCP for a new suit response at the 2-level. Typically 10.</summary>
+    public int MinHcpFor2Level { get; init; }
+
+    /// <summary>Maximum HCP for a simple raise (2-level). Typically 9.</summary>
+    public int RaiseTo2MaxHcp { get; init; }
+
+    /// <summary>Maximum HCP for a limit raise (3-level). Typically 12.</summary>
+    public int RaiseTo3MaxHcp { get; init; }
+
+    /// <summary>Minimum HCP for a game-forcing response. Typically 13.</summary>
+    public int GameForceMinHcp { get; init; }
+
+    /// <summary>Minimum HCP for a 1NT response. Typically 6.</summary>
+    public int NTResponseMinHcp { get; init; }
+
+    /// <summary>Maximum HCP for a 1NT response. Typically 9.</summary>
+    public int NTResponseMaxHcp { get; init; }
+
+    /// <summary>Whether splinter bids are played in response to 1-suit openings.</summary>
+    public bool SplinterBids { get; init; }
+}
+
+/// <summary>
+/// Configuration for responses to a strong 2C opening.
+/// </summary>
+public record ResponseTo2CConfig
+{
+    public bool Enabled { get; init; }
+
+    /// <summary>The negative response bid. "2D" for standard, "2H" for Benji.</summary>
+    public string NegativeResponseBid { get; init; } = "2D";
+}

--- a/BridgeIt.Systems/LoadedSystem.cs
+++ b/BridgeIt.Systems/LoadedSystem.cs
@@ -1,0 +1,14 @@
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Systems.Config;
+
+namespace BridgeIt.Systems;
+
+/// <summary>
+/// The result of loading a bidding system from config.
+/// Contains the instantiated rule list, the source config, and any warnings.
+/// </summary>
+public record LoadedSystem(
+    string Name,
+    IReadOnlyList<IBiddingRule> Rules,
+    BridgeSystemConfig Config,
+    List<string> Warnings);

--- a/BridgeIt.Systems/Systems/acol-benji.json
+++ b/BridgeIt.Systems/Systems/acol-benji.json
@@ -1,0 +1,246 @@
+{
+  "name": "Benjaminised Acol",
+  "description": "Acol with Benjamin twos (2C = Acol 2 or 21-22 balanced, 2D = game force). Transfers, minor transfers, RKCB. Suitable for intermediate/advanced players.",
+
+  "nT1Opening": {
+    "minHcp": 12,
+    "maxHcp": 14,
+    "level": 1,
+    "allowSingleton": false
+  },
+
+  "nT2Opening": {
+    "minHcp": 19,
+    "maxHcp": 20,
+    "level": 2,
+    "allowSingleton": false
+  },
+
+  "suitOpening": {
+    "minHcp": 11,
+    "maxHcp": 19,
+    "majorMinLength": 4,
+    "minorMinLength": 4,
+    "minorSelection": "HigherRanking",
+    "ruleOf20": false,
+    "fourCardMajor": {
+      "fourFourMajorOpening": "1H",
+      "fourFourFourOneMap": {
+        "Clubs": "1H",
+        "Diamonds": "1C",
+        "Hearts": "1D",
+        "Spades": "1D"
+      }
+    }
+  },
+
+  "strongOpening": {
+    "minHcpBalanced": 23,
+    "minHcpUnbalanced": 20,
+    "maxHcp": 35,
+    "bid": "2D",
+    "gameForcing": true
+  },
+
+  "preempts": {
+    "minHcp": 6,
+    "maxHcp": 10,
+    "minSuitLength3Level": 6,
+    "minSuitLength4Level": 7,
+    "reservedBids": ["2C", "2D"]
+  },
+
+  "twoLevelOpenings": {
+    "benjaminTwos": true,
+    "weakTwos": {
+      "minHcp": 5,
+      "maxHcp": 9,
+      "minSuitLength": 6,
+      "suits": ["H", "S"],
+      "twoNTEnquiry": true
+    },
+    "acolTwos": {
+      "minHcp": 16,
+      "maxHcp": 22,
+      "suits": ["D", "H", "S"]
+    }
+  },
+
+  "responseTo1NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 11
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": {
+      "enabled": true,
+      "clubTransferBid": "2S",
+      "diamondTransferBid": "2NT"
+    },
+    "baron": null,
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": true
+  },
+
+  "responseTo2NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 4
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": null,
+    "baron": {
+      "enabled": true,
+      "bid": "3S",
+      "inviteMinHcp": 11,
+      "inviteMaxHcp": 12
+    },
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo1Suit": {
+    "minHcpFor1Level": 6,
+    "minHcpFor2Level": 10,
+    "raiseTo2MaxHcp": 9,
+    "raiseTo3MaxHcp": 12,
+    "gameForceMinHcp": 13,
+    "nTResponseMinHcp": 6,
+    "nTResponseMaxHcp": 9,
+    "splinterBids": true
+  },
+
+  "responseTo2C": {
+    "enabled": true,
+    "negativeResponseBid": "2H"
+  },
+
+  "openerRebid": {
+    "reverseMinHcp": 16,
+    "nTRebid": {
+      "rebid1NTMin": 15,
+      "rebid1NTMax": 17,
+      "rebid2NTMin": 18,
+      "rebid2NTMax": 19,
+      "rebid3NTMin": 20,
+      "rebid3NTMax": 22
+    }
+  },
+
+  "responderRebid": {},
+
+  "overcalls": {
+    "simple": { "minHcp": 8 },
+    "jump": {
+      "style": "Weak",
+      "minHcp": 6,
+      "maxHcp": 10,
+      "minSuitLength": 6
+    },
+    "cueBid": {
+      "enabled": true,
+      "style": "Michaels",
+      "minSuitLength": 5
+    },
+    "nT1": {
+      "directMinHcp": 16,
+      "directMaxHcp": 18,
+      "protectiveMinHcp": 11,
+      "protectiveMaxHcp": 14
+    },
+    "unusual2NT": {
+      "enabled": true
+    }
+  },
+
+  "negativeDoubles": {
+    "enabled": true,
+    "maxLevel": "3S"
+  },
+
+  "competitiveAuctions": {
+    "redoubleShows9Plus": true,
+    "newSuitForcing": true,
+    "jumpRaisePreemptive": true,
+    "twoNTGoodRaise": true,
+    "unassumingCueBids": {
+      "enabled": true
+    }
+  },
+
+  "slam": {
+    "style": "RKCB",
+    "grandSlamForce": true
+  },
+
+  "fourthSuitForcing": {
+    "enabled": true
+  },
+
+  "splinters": {
+    "enabled": true,
+    "minFitLength": 4
+  },
+
+  "trialBids": null,
+
+  "priorities": {
+    "Acol1NTOpening": 20,
+    "Acol2NTOpening": 20,
+    "Acol1SuitOpening": 10,
+    "AcolStrongOpening": 19,
+    "WeakOpening": 9,
+    "StandardStayman_1NT": 29,
+    "StandardStayman_2NT": 29,
+    "StandardStayman_2C2D2NT": 29,
+    "StandardTransfer_1NT": 30,
+    "StandardTransfer_2NT": 30,
+    "StandardTransfer_2C2D2NT": 30,
+    "CompleteTransfer_1NT": 30,
+    "CompleteTransfer_2NT": 30,
+    "CompleteTransfer_2C2D2NT": 30,
+    "StaymanResponse_1NT": 60,
+    "StaymanResponse_2NT": 60,
+    "StaymanResponse_2C2D2NT": 60,
+    "AcolResponderAfterStayman_1NT": 58,
+    "AcolResponderAfterStayman_2NT": 58,
+    "AcolResponderAfterStayman_2C2D2NT": 58,
+    "AcolNTRaiseOver1NT": 25,
+    "AcolResponseTo2C": 50,
+    "AcolJacoby2NTOver1Major": 55,
+    "AcolRaiseMajorOver1Suit": 50,
+    "AcolRaiseMinorOver1Suit": 35,
+    "AcolNewSuitOver1Suit": 40,
+    "Acol1NTResponseTo1Suit": 30,
+    "AcolOpenerRebidAfter2C": 60,
+    "AcolOpenerAfterNTInvite": 50,
+    "AcolOpenerAfterMajorRaise": 45,
+    "AcolRebidBalanced": 25,
+    "AcolRebidNewSuit": 40,
+    "AcolRebidRaiseSuit": 35,
+    "AcolRebidOwnSuit": 42,
+    "AcolResponderAfterOpenerRaisedSuit": 50,
+    "AcolResponderAfterOpener1NTRebid": 45,
+    "AcolResponderAfterOpener2NTRebid": 45,
+    "AcolResponderAfterOpenerRebidOwnSuit": 40,
+    "AcolResponderAfterOpenerNewSuit": 40,
+    "KnowledgeBidGameInSuit": 2,
+    "KnowledgeBidGameInNT": 1,
+    "KnowledgeInviteInSuit": 2,
+    "KnowledgeInviteInNT": 2,
+    "KnowledgeSignOffInFit": 1,
+    "KnowledgeSignOff": 0
+  }
+}

--- a/BridgeIt.Systems/Systems/acol-foundation.json
+++ b/BridgeIt.Systems/Systems/acol-foundation.json
@@ -1,0 +1,220 @@
+{
+  "name": "Standard English Acol (Foundation)",
+  "description": "BFA Foundation Level. Weak 1NT, no transfers (weakness takeouts), strong 2C, weak 2s. Suitable for beginners.",
+
+  "nT1Opening": {
+    "minHcp": 12,
+    "maxHcp": 14,
+    "level": 1,
+    "allowSingleton": false
+  },
+
+  "nT2Opening": {
+    "minHcp": 20,
+    "maxHcp": 22,
+    "level": 2,
+    "allowSingleton": false
+  },
+
+  "suitOpening": {
+    "minHcp": 12,
+    "maxHcp": 19,
+    "majorMinLength": 4,
+    "minorMinLength": 4,
+    "minorSelection": "HigherRanking",
+    "ruleOf20": true,
+    "fourCardMajor": {
+      "fourFourMajorOpening": "1H",
+      "fourFourFourOneMap": {
+        "Clubs": "1H",
+        "Diamonds": "1C",
+        "Hearts": "1D",
+        "Spades": "1D"
+      }
+    }
+  },
+
+  "strongOpening": {
+    "minHcpBalanced": 23,
+    "minHcpUnbalanced": 20,
+    "maxHcp": 35,
+    "bid": "2C",
+    "gameForcing": true
+  },
+
+  "preempts": {
+    "minHcp": 6,
+    "maxHcp": 10,
+    "minSuitLength3Level": 7,
+    "minSuitLength4Level": 8,
+    "reservedBids": ["2C"]
+  },
+
+  "twoLevelOpenings": {
+    "benjaminTwos": false,
+    "weakTwos": {
+      "minHcp": 5,
+      "maxHcp": 9,
+      "minSuitLength": 6,
+      "suits": ["H", "S"],
+      "twoNTEnquiry": true
+    },
+    "acolTwos": null
+  },
+
+  "responseTo1NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 11
+    },
+    "transfers": null,
+    "minorTransfers": null,
+    "baron": null,
+    "weaknessTakeouts": {
+      "enabled": true,
+      "bids": ["2D", "2H", "2S"]
+    },
+    "raise": {
+      "enabled": true,
+      "inviteMinHcp": 11,
+      "inviteMaxHcp": 12
+    },
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo2NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 4
+    },
+    "transfers": null,
+    "minorTransfers": null,
+    "baron": null,
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo1Suit": {
+    "minHcpFor1Level": 6,
+    "minHcpFor2Level": 10,
+    "raiseTo2MaxHcp": 9,
+    "raiseTo3MaxHcp": 12,
+    "gameForceMinHcp": 13,
+    "nTResponseMinHcp": 6,
+    "nTResponseMaxHcp": 9,
+    "splinterBids": false
+  },
+
+  "responseTo2C": {
+    "enabled": true,
+    "negativeResponseBid": "2D"
+  },
+
+  "openerRebid": {
+    "reverseMinHcp": 16,
+    "nTRebid": {
+      "rebid1NTMin": 15,
+      "rebid1NTMax": 16,
+      "rebid2NTMin": 17,
+      "rebid2NTMax": 18,
+      "rebid3NTMin": 19,
+      "rebid3NTMax": 19
+    }
+  },
+
+  "responderRebid": {},
+
+  "overcalls": {
+    "simple": { "minHcp": 8 },
+    "jump": {
+      "style": "Intermediate",
+      "minHcp": 12,
+      "maxHcp": 16,
+      "minSuitLength": 6
+    },
+    "cueBid": null,
+    "nT1": {
+      "directMinHcp": 15,
+      "directMaxHcp": 17,
+      "protectiveMinHcp": 12,
+      "protectiveMaxHcp": 14
+    },
+    "unusual2NT": null
+  },
+
+  "negativeDoubles": {
+    "enabled": true,
+    "maxLevel": "2S"
+  },
+
+  "competitiveAuctions": {
+    "redoubleShows9Plus": true,
+    "newSuitForcing": true,
+    "jumpRaisePreemptive": true,
+    "twoNTGoodRaise": true,
+    "unassumingCueBids": null
+  },
+
+  "slam": {
+    "style": "Blackwood",
+    "grandSlamForce": true
+  },
+
+  "fourthSuitForcing": {
+    "enabled": true
+  },
+
+  "splinters": null,
+  "trialBids": null,
+
+  "priorities": {
+    "Acol1NTOpening": 20,
+    "Acol2NTOpening": 20,
+    "Acol1SuitOpening": 10,
+    "AcolStrongOpening": 19,
+    "WeakOpening": 9,
+    "StandardStayman_1NT": 29,
+    "StandardStayman_2NT": 29,
+    "StandardStayman_2C2D2NT": 29,
+    "StandardTransfer_1NT": 30,
+    "StandardTransfer_2NT": 30,
+    "StandardTransfer_2C2D2NT": 30,
+    "CompleteTransfer_1NT": 30,
+    "CompleteTransfer_2NT": 30,
+    "CompleteTransfer_2C2D2NT": 30,
+    "StaymanResponse_1NT": 60,
+    "StaymanResponse_2NT": 60,
+    "StaymanResponse_2C2D2NT": 60,
+    "AcolResponderAfterStayman_1NT": 58,
+    "AcolResponderAfterStayman_2NT": 58,
+    "AcolResponderAfterStayman_2C2D2NT": 58,
+    "AcolNTRaiseOver1NT": 25,
+    "AcolResponseTo2C": 50,
+    "AcolJacoby2NTOver1Major": 55,
+    "AcolRaiseMajorOver1Suit": 50,
+    "AcolRaiseMinorOver1Suit": 35,
+    "AcolNewSuitOver1Suit": 40,
+    "Acol1NTResponseTo1Suit": 30,
+    "AcolOpenerRebidAfter2C": 60,
+    "AcolOpenerAfterNTInvite": 50,
+    "AcolOpenerAfterMajorRaise": 45,
+    "AcolRebidBalanced": 25,
+    "AcolRebidNewSuit": 40,
+    "AcolRebidRaiseSuit": 35,
+    "AcolRebidOwnSuit": 42,
+    "AcolResponderAfterOpenerRaisedSuit": 50,
+    "AcolResponderAfterOpener1NTRebid": 45,
+    "AcolResponderAfterOpener2NTRebid": 45,
+    "AcolResponderAfterOpenerRebidOwnSuit": 40,
+    "AcolResponderAfterOpenerNewSuit": 40,
+    "KnowledgeBidGameInSuit": 2,
+    "KnowledgeBidGameInNT": 1,
+    "KnowledgeInviteInSuit": 2,
+    "KnowledgeInviteInNT": 2,
+    "KnowledgeSignOffInFit": 1,
+    "KnowledgeSignOff": 0
+  }
+}

--- a/BridgeIt.Systems/Systems/acol-modern.json
+++ b/BridgeIt.Systems/Systems/acol-modern.json
@@ -1,0 +1,254 @@
+{
+  "name": "Modern Acol (BFA Level 2)",
+  "description": "BFA Level 2. Transfers, Baron, splinters, long suit trial bids, Michaels, unusual 2NT. For club-level players moving beyond foundation.",
+
+  "nT1Opening": {
+    "minHcp": 12,
+    "maxHcp": 14,
+    "level": 1,
+    "allowSingleton": false
+  },
+
+  "nT2Opening": {
+    "minHcp": 20,
+    "maxHcp": 22,
+    "level": 2,
+    "allowSingleton": false
+  },
+
+  "suitOpening": {
+    "minHcp": 12,
+    "maxHcp": 19,
+    "majorMinLength": 4,
+    "minorMinLength": 4,
+    "minorSelection": "HigherRanking",
+    "ruleOf20": true,
+    "fourCardMajor": {
+      "fourFourMajorOpening": "1H",
+      "fourFourFourOneMap": {
+        "Clubs": "1H",
+        "Diamonds": "1C",
+        "Hearts": "1D",
+        "Spades": "1D"
+      }
+    }
+  },
+
+  "strongOpening": {
+    "minHcpBalanced": 23,
+    "minHcpUnbalanced": 20,
+    "maxHcp": 35,
+    "bid": "2C",
+    "gameForcing": true
+  },
+
+  "preempts": {
+    "minHcp": 6,
+    "maxHcp": 10,
+    "minSuitLength3Level": 7,
+    "minSuitLength4Level": 8,
+    "reservedBids": ["2C"]
+  },
+
+  "twoLevelOpenings": {
+    "benjaminTwos": false,
+    "weakTwos": {
+      "minHcp": 5,
+      "maxHcp": 9,
+      "minSuitLength": 6,
+      "suits": ["H", "S"],
+      "twoNTEnquiry": true
+    },
+    "acolTwos": {
+      "minHcp": 16,
+      "maxHcp": 22,
+      "suits": ["D", "H", "S"]
+    }
+  },
+
+  "responseTo1NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 11
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": {
+      "enabled": true,
+      "clubTransferBid": null,
+      "diamondTransferBid": "2NT"
+    },
+    "baron": {
+      "enabled": true,
+      "bid": "2S",
+      "inviteMinHcp": 11,
+      "inviteMaxHcp": 12
+    },
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": true
+  },
+
+  "responseTo2NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 4
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": null,
+    "baron": {
+      "enabled": true,
+      "bid": "3S",
+      "inviteMinHcp": 11,
+      "inviteMaxHcp": 12
+    },
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo1Suit": {
+    "minHcpFor1Level": 6,
+    "minHcpFor2Level": 10,
+    "raiseTo2MaxHcp": 9,
+    "raiseTo3MaxHcp": 12,
+    "gameForceMinHcp": 13,
+    "nTResponseMinHcp": 6,
+    "nTResponseMaxHcp": 9,
+    "splinterBids": true
+  },
+
+  "responseTo2C": {
+    "enabled": true,
+    "negativeResponseBid": "2D"
+  },
+
+  "openerRebid": {
+    "reverseMinHcp": 16,
+    "nTRebid": {
+      "rebid1NTMin": 15,
+      "rebid1NTMax": 16,
+      "rebid2NTMin": 17,
+      "rebid2NTMax": 18,
+      "rebid3NTMin": 19,
+      "rebid3NTMax": 19
+    }
+  },
+
+  "responderRebid": {},
+
+  "overcalls": {
+    "simple": { "minHcp": 8 },
+    "jump": {
+      "style": "Intermediate",
+      "minHcp": 12,
+      "maxHcp": 16,
+      "minSuitLength": 6
+    },
+    "cueBid": {
+      "enabled": true,
+      "style": "Michaels",
+      "minSuitLength": 5
+    },
+    "nT1": {
+      "directMinHcp": 16,
+      "directMaxHcp": 18,
+      "protectiveMinHcp": 11,
+      "protectiveMaxHcp": 14
+    },
+    "unusual2NT": {
+      "enabled": true
+    }
+  },
+
+  "negativeDoubles": {
+    "enabled": true,
+    "maxLevel": "2S"
+  },
+
+  "competitiveAuctions": {
+    "redoubleShows9Plus": true,
+    "newSuitForcing": true,
+    "jumpRaisePreemptive": true,
+    "twoNTGoodRaise": true,
+    "unassumingCueBids": {
+      "enabled": true
+    }
+  },
+
+  "slam": {
+    "style": "Blackwood",
+    "grandSlamForce": true
+  },
+
+  "fourthSuitForcing": {
+    "enabled": true
+  },
+
+  "splinters": {
+    "enabled": true,
+    "minFitLength": 4
+  },
+
+  "trialBids": {
+    "enabled": true,
+    "style": "LongSuit"
+  },
+
+  "priorities": {
+    "Acol1NTOpening": 20,
+    "Acol2NTOpening": 20,
+    "Acol1SuitOpening": 10,
+    "AcolStrongOpening": 19,
+    "WeakOpening": 9,
+    "StandardStayman_1NT": 29,
+    "StandardStayman_2NT": 29,
+    "StandardStayman_2C2D2NT": 29,
+    "StandardTransfer_1NT": 30,
+    "StandardTransfer_2NT": 30,
+    "StandardTransfer_2C2D2NT": 30,
+    "CompleteTransfer_1NT": 30,
+    "CompleteTransfer_2NT": 30,
+    "CompleteTransfer_2C2D2NT": 30,
+    "StaymanResponse_1NT": 60,
+    "StaymanResponse_2NT": 60,
+    "StaymanResponse_2C2D2NT": 60,
+    "AcolResponderAfterStayman_1NT": 58,
+    "AcolResponderAfterStayman_2NT": 58,
+    "AcolResponderAfterStayman_2C2D2NT": 58,
+    "AcolNTRaiseOver1NT": 25,
+    "AcolResponseTo2C": 50,
+    "AcolJacoby2NTOver1Major": 55,
+    "AcolRaiseMajorOver1Suit": 50,
+    "AcolRaiseMinorOver1Suit": 35,
+    "AcolNewSuitOver1Suit": 40,
+    "Acol1NTResponseTo1Suit": 30,
+    "AcolOpenerRebidAfter2C": 60,
+    "AcolOpenerAfterNTInvite": 50,
+    "AcolOpenerAfterMajorRaise": 45,
+    "AcolRebidBalanced": 25,
+    "AcolRebidNewSuit": 40,
+    "AcolRebidRaiseSuit": 35,
+    "AcolRebidOwnSuit": 42,
+    "AcolResponderAfterOpenerRaisedSuit": 50,
+    "AcolResponderAfterOpener1NTRebid": 45,
+    "AcolResponderAfterOpener2NTRebid": 45,
+    "AcolResponderAfterOpenerRebidOwnSuit": 40,
+    "AcolResponderAfterOpenerNewSuit": 40,
+    "KnowledgeBidGameInSuit": 2,
+    "KnowledgeBidGameInNT": 1,
+    "KnowledgeInviteInSuit": 2,
+    "KnowledgeInviteInNT": 2,
+    "KnowledgeSignOffInFit": 1,
+    "KnowledgeSignOff": 0
+  }
+}

--- a/BridgeIt.Systems/Systems/sayc.json
+++ b/BridgeIt.Systems/Systems/sayc.json
@@ -1,0 +1,216 @@
+{
+  "name": "Standard American Yellow Card (SAYC)",
+  "description": "Standard American. Strong 1NT (15-17), 5-card majors, better minor, weak 2D/H/S, Jacoby 2NT, Blackwood. The most widely played system in North America.",
+
+  "nT1Opening": {
+    "minHcp": 15,
+    "maxHcp": 17,
+    "level": 1,
+    "allowSingleton": false
+  },
+
+  "nT2Opening": {
+    "minHcp": 20,
+    "maxHcp": 21,
+    "level": 2,
+    "allowSingleton": false
+  },
+
+  "suitOpening": {
+    "minHcp": 12,
+    "maxHcp": 21,
+    "majorMinLength": 5,
+    "minorMinLength": 3,
+    "minorSelection": "BetterMinor",
+    "ruleOf20": false,
+    "fourCardMajor": null
+  },
+
+  "strongOpening": {
+    "minHcpBalanced": 22,
+    "minHcpUnbalanced": 20,
+    "maxHcp": 37,
+    "bid": "2C",
+    "gameForcing": true
+  },
+
+  "preempts": {
+    "minHcp": 5,
+    "maxHcp": 10,
+    "minSuitLength3Level": 7,
+    "minSuitLength4Level": 8,
+    "reservedBids": ["2C"]
+  },
+
+  "twoLevelOpenings": {
+    "benjaminTwos": false,
+    "weakTwos": {
+      "minHcp": 5,
+      "maxHcp": 11,
+      "minSuitLength": 6,
+      "suits": ["D", "H", "S"],
+      "twoNTEnquiry": true
+    },
+    "acolTwos": null
+  },
+
+  "responseTo1NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 8
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": null,
+    "baron": null,
+    "weaknessTakeouts": null,
+    "raise": {
+      "enabled": true,
+      "inviteMinHcp": 8,
+      "inviteMaxHcp": 9
+    },
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo2NT": {
+    "stayman": {
+      "enabled": true,
+      "minHcp": 4
+    },
+    "transfers": {
+      "enabled": true,
+      "minSuitLength": 5,
+      "maxSuitLength": 11
+    },
+    "minorTransfers": null,
+    "baron": null,
+    "weaknessTakeouts": null,
+    "raise": null,
+    "jacoby2NT": null,
+    "naturalAfterDouble": false
+  },
+
+  "responseTo1Suit": {
+    "minHcpFor1Level": 6,
+    "minHcpFor2Level": 10,
+    "raiseTo2MaxHcp": 10,
+    "raiseTo3MaxHcp": 12,
+    "gameForceMinHcp": 13,
+    "nTResponseMinHcp": 6,
+    "nTResponseMaxHcp": 10,
+    "splinterBids": false
+  },
+
+  "responseTo2C": {
+    "enabled": true,
+    "negativeResponseBid": "2D"
+  },
+
+  "openerRebid": {
+    "reverseMinHcp": 17,
+    "nTRebid": {
+      "rebid1NTMin": 12,
+      "rebid1NTMax": 14,
+      "rebid2NTMin": 18,
+      "rebid2NTMax": 19,
+      "rebid3NTMin": 20,
+      "rebid3NTMax": 21
+    }
+  },
+
+  "responderRebid": {},
+
+  "overcalls": {
+    "simple": { "minHcp": 8 },
+    "jump": {
+      "style": "Weak",
+      "minHcp": 5,
+      "maxHcp": 10,
+      "minSuitLength": 6
+    },
+    "cueBid": {
+      "enabled": true,
+      "style": "Michaels",
+      "minSuitLength": 5
+    },
+    "nT1": {
+      "directMinHcp": 15,
+      "directMaxHcp": 18,
+      "protectiveMinHcp": 11,
+      "protectiveMaxHcp": 14
+    },
+    "unusual2NT": {
+      "enabled": true
+    }
+  },
+
+  "negativeDoubles": {
+    "enabled": true,
+    "maxLevel": "3S"
+  },
+
+  "competitiveAuctions": {
+    "redoubleShows9Plus": true,
+    "newSuitForcing": true,
+    "jumpRaisePreemptive": true,
+    "twoNTGoodRaise": true,
+    "unassumingCueBids": null
+  },
+
+  "slam": {
+    "style": "Blackwood",
+    "grandSlamForce": false
+  },
+
+  "fourthSuitForcing": {
+    "enabled": true
+  },
+
+  "splinters": null,
+  "trialBids": null,
+
+  "priorities": {
+    "Acol1NTOpening": 20,
+    "Acol2NTOpening": 20,
+    "Acol1SuitOpening": 10,
+    "AcolStrongOpening": 19,
+    "WeakOpening": 9,
+    "StandardStayman_1NT": 29,
+    "StandardStayman_2NT": 29,
+    "StandardTransfer_1NT": 30,
+    "StandardTransfer_2NT": 30,
+    "CompleteTransfer_1NT": 30,
+    "CompleteTransfer_2NT": 30,
+    "StaymanResponse_1NT": 60,
+    "StaymanResponse_2NT": 60,
+    "AcolNTRaiseOver1NT": 25,
+    "AcolResponseTo2C": 50,
+    "AcolJacoby2NTOver1Major": 55,
+    "AcolRaiseMajorOver1Suit": 50,
+    "AcolRaiseMinorOver1Suit": 35,
+    "AcolNewSuitOver1Suit": 40,
+    "Acol1NTResponseTo1Suit": 30,
+    "AcolOpenerRebidAfter2C": 60,
+    "AcolOpenerAfterNTInvite": 50,
+    "AcolOpenerAfterMajorRaise": 45,
+    "AcolRebidBalanced": 25,
+    "AcolRebidNewSuit": 40,
+    "AcolRebidRaiseSuit": 35,
+    "AcolRebidOwnSuit": 42,
+    "AcolResponderAfterOpenerRaisedSuit": 50,
+    "AcolResponderAfterOpener1NTRebid": 45,
+    "AcolResponderAfterOpener2NTRebid": 45,
+    "AcolResponderAfterOpenerRebidOwnSuit": 40,
+    "AcolResponderAfterOpenerNewSuit": 40,
+    "KnowledgeBidGameInSuit": 2,
+    "KnowledgeBidGameInNT": 1,
+    "KnowledgeInviteInSuit": 2,
+    "KnowledgeInviteInNT": 2,
+    "KnowledgeSignOffInFit": 1,
+    "KnowledgeSignOff": 0
+  }
+}

--- a/BridgeIt.TestHarness/BridgeIt.TestHarness.csproj
+++ b/BridgeIt.TestHarness/BridgeIt.TestHarness.csproj
@@ -72,6 +72,7 @@
       <ProjectReference Include="..\BridgeIt.Analysis\BridgeIt.Analysis.csproj" />
       <ProjectReference Include="..\BridgeIt.Core\BridgeIt.Core.csproj" />
       <ProjectReference Include="..\BridgeIt.Dealer\BridgeIt.Dealer.csproj" />
+      <ProjectReference Include="..\BridgeIt.Systems\BridgeIt.Systems.csproj" />
     </ItemGroup>
 
 </Project>

--- a/BridgeIt.TestHarness/Setup/TestBridgeEnvironment.cs
+++ b/BridgeIt.TestHarness/Setup/TestBridgeEnvironment.cs
@@ -2,21 +2,12 @@ using Microsoft.Extensions.DependencyInjection;
 using BridgeIt.Core.BiddingEngine.Core;
 using BridgeIt.Core.BiddingEngine.EngineObserver;
 using BridgeIt.Core.BiddingEngine.RuleLookupService;
-using BridgeIt.Core.BiddingEngine.Conventions;
-using BridgeIt.Core.BiddingEngine.Rules.Knowledge;
-using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
-using BridgeIt.Core.BiddingEngine.Rules.Openings;
-using BridgeIt.Core.BiddingEngine.Rules.Responder;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1NT;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
-using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
-using BridgeIt.Core.Configuration.Yaml;
-using BridgeIt.Core.Domain.Bidding;
 using BridgeIt.Core.Domain.Primatives;
 using BridgeIt.Core.Gameplay.Table;
 using BridgeIt.Core.Extensions;
 using BridgeIt.Core.Gameplay.Output;
 using BridgeIt.Core.Players;
+using BridgeIt.Systems;
 using Microsoft.Extensions.Logging;
 
 
@@ -40,14 +31,14 @@ public class TestBridgeEnvironment
     private void Initialize()
     {
         var services = new ServiceCollection();
-        
+
         // 1. Core Dependencies (Factories, etc.)
-        services.AddBridgeItCore(); 
-        
+        services.AddBridgeItCore();
+
         // 2. Register Observers
         services.AddSingleton<IBiddingObserver, ConsoleBiddingObserver>();
-        
-        services.AddLogging(builder => 
+
+        services.AddLogging(builder =>
         {
             builder.AddConsole();
             builder.AddDebug();
@@ -56,84 +47,18 @@ public class TestBridgeEnvironment
 
         Provider = services.BuildServiceProvider();
     }
-    
+
     public TestBridgeEnvironment WithAllRules()
     {
-        var basePath = AppDomain.CurrentDomain.BaseDirectory;
-        var fullPath = Path.Combine(basePath, "BiddingRules");
-        
-        //var loader = Provider.GetRequiredService<YamlRuleLoader>();
-        //var rules = loader.LoadRulesFromDirectory(fullPath).ToList();
-        
-        var rules = new List<IBiddingRule>();
-        
-        // Opening rules
-        rules.Add(new WeakOpeningRule(reservedBids: [Bid.SuitBid(2, Suit.Clubs)]));
-        rules.Add(new Acol1SuitOpeningRule());
-        rules.Add(new Acol1NTOpeningRule());
-        rules.Add(new Acol2NTOpeningRule());
-        rules.Add(new AcolStrongOpening());
-
-        // Response to 2C
-        rules.Add(new AcolResponseTo2C());
-
-        rules.Add(new StandardTransfer(NTConventionContexts.After1NT));
-        rules.Add(new StandardStayman(NTConventionContexts.After1NT));
-        rules.Add(new AcolNTRaiseOver1NT());
-
-        rules.Add(new StandardTransfer(NTConventionContexts.After2NT));
-        rules.Add(new StandardStayman(NTConventionContexts.After2NT));
-
-        rules.Add(new StandardTransfer(NTConventionContexts.After2C2D2NT));
-        rules.Add(new StandardStayman(NTConventionContexts.After2C2D2NT));
-
-        rules.Add(new AcolJacoby2NTOver1Major());
-        rules.Add(new AcolRaiseMajorOver1Suit());
-        rules.Add(new AcolRaiseMinorOver1Suit());
-        rules.Add(new AcolNewSuitOver1Suit());
-        rules.Add(new Acol1NTResponseTo1Suit());
-
-        rules.Add(new CompleteTransfer(NTConventionContexts.After1NT));
-        rules.Add(new CompleteTransfer(NTConventionContexts.After2NT));
-        rules.Add(new CompleteTransfer(NTConventionContexts.After2C2D2NT));
-
-        rules.Add(new StaymanResponse(NTConventionContexts.After1NT));
-        rules.Add(new StaymanResponse(NTConventionContexts.After2NT));
-        rules.Add(new StaymanResponse(NTConventionContexts.After2C2D2NT));
-
-        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After1NT));
-        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After2NT));
-        rules.Add(new AcolResponderAfterStayman(NTConventionContexts.After2C2D2NT));
-
-        // Opener rebid rules
-        rules.Add(new AcolOpenerRebidAfter2C());
-        rules.Add(new AcolOpenerAfterNTInvite());
-        rules.Add(new AcolOpenerAfterMajorRaise());
-        rules.Add(new AcolRebidBalanced());
-        rules.Add(new AcolRebidNewSuit());
-        rules.Add(new AcolRebidRaiseSuit());
-        rules.Add(new AcolRebidOwnSuit());
-
-        // Responder rebids (round 2)
-        rules.Add(new AcolResponderAfterOpenerRaisedSuit());
-        rules.Add(new AcolResponderAfterOpener1NTRebid());
-        rules.Add(new AcolResponderAfterOpener2NTRebid());
-        rules.Add(new AcolResponderAfterOpenerRebidOwnSuit());
-        rules.Add(new AcolResponderAfterOpenerNewSuit());
-
-        // Knowledge-based catch-all rules
-        rules.Add(new KnowledgeBidGameInSuit());
-        rules.Add(new KnowledgeBidGameInNT());
-        rules.Add(new KnowledgeInviteInSuit());
-        rules.Add(new KnowledgeInviteInNT());
-        rules.Add(new KnowledgeSignOffInFit());
-        rules.Add(new KnowledgeSignOff());
+        var loader = new BiddingSystemLoader();
+        var systemPath = FindSystemFile("acol-foundation.json");
+        var loaded = loader.LoadFromFile(systemPath);
 
         var observer = Provider.GetRequiredService<IEngineObserver>();
         var logger = Provider.GetRequiredService<ILogger<BiddingEngine>>();
-        
-        Engine = new BiddingEngine(rules, logger, observer);
-        
+
+        Engine = new BiddingEngine(loaded.Rules, logger, observer);
+
         var robotPlayer = new RobotPlayer(Engine, Provider.GetRequiredService<IRuleLookupService>());
 
         Players = new Dictionary<Seat, IPlayer>()
@@ -145,6 +70,19 @@ public class TestBridgeEnvironment
         };
         RebuildTable();
         return this;
+    }
+
+    private static string FindSystemFile(string filename)
+    {
+        // Walk up from test output directory to find BridgeIt.Systems/Systems/
+        var dir = AppDomain.CurrentDomain.BaseDirectory;
+        for (var i = 0; i < 8; i++)
+        {
+            var candidate = Path.Combine(dir, "BridgeIt.Systems", "Systems", filename);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir)!;
+        }
+        throw new FileNotFoundException($"Could not find system file: {filename}");
     }
 
     private void RebuildTable()

--- a/BridgeIt.Tests/BiddingEngine/SystemConfigTests.cs
+++ b/BridgeIt.Tests/BiddingEngine/SystemConfigTests.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+using BridgeIt.Systems;
+using BridgeIt.Systems.Config;
+
+namespace BridgeIt.Tests.BiddingEngine;
+
+[TestFixture]
+public class SystemConfigTests
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+
+    private static string SystemsDir =>
+        Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..",
+            "BridgeIt.Systems", "Systems");
+
+    private static BridgeSystemConfig LoadSystem(string filename)
+    {
+        var path = Path.Combine(SystemsDir, filename);
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<BridgeSystemConfig>(json, JsonOpts)!;
+    }
+
+    [TestCase("acol-foundation.json")]
+    [TestCase("acol-benji.json")]
+    [TestCase("acol-modern.json")]
+    [TestCase("sayc.json")]
+    public void SystemFile_Deserialises_Successfully(string filename)
+    {
+        var config = LoadSystem(filename);
+        Assert.That(config, Is.Not.Null);
+        Assert.That(config.Name, Is.Not.Null.And.Not.Empty);
+    }
+
+    [TestCase("acol-foundation.json")]
+    [TestCase("acol-benji.json")]
+    [TestCase("acol-modern.json")]
+    [TestCase("sayc.json")]
+    public void SystemFile_Has_Priorities(string filename)
+    {
+        var config = LoadSystem(filename);
+        Assert.That(config.Priorities, Is.Not.Null);
+        Assert.That(config.Priorities!.Count, Is.GreaterThan(10));
+    }
+
+    [Test]
+    public void Foundation_Has_WeaknessTakeouts_NoTransfers()
+    {
+        var config = LoadSystem("acol-foundation.json");
+        Assert.That(config.ResponseTo1NT?.WeaknessTakeouts?.Enabled, Is.True);
+        Assert.That(config.ResponseTo1NT?.Transfers, Is.Null);
+    }
+
+    [Test]
+    public void Benji_Has_Transfers_And_MinorTransfers()
+    {
+        var config = LoadSystem("acol-benji.json");
+        Assert.That(config.ResponseTo1NT?.Transfers?.Enabled, Is.True);
+        Assert.That(config.ResponseTo1NT?.MinorTransfers?.Enabled, Is.True);
+        Assert.That(config.ResponseTo1NT?.MinorTransfers?.ClubTransferBid, Is.EqualTo("2S"));
+    }
+
+    [Test]
+    public void Benji_Has_BenjaminTwos_With_2D_GameForce()
+    {
+        var config = LoadSystem("acol-benji.json");
+        Assert.That(config.TwoLevelOpenings?.BenjaminTwos, Is.True);
+        Assert.That(config.StrongOpening?.Bid, Is.EqualTo("2D"));
+        Assert.That(config.StrongOpening?.GameForcing, Is.True);
+    }
+
+    [Test]
+    public void Benji_2NT_Is_19_20()
+    {
+        var config = LoadSystem("acol-benji.json");
+        Assert.That(config.NT2Opening?.MinHcp, Is.EqualTo(19));
+        Assert.That(config.NT2Opening?.MaxHcp, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Modern_Has_Transfers_Baron_Splinters()
+    {
+        var config = LoadSystem("acol-modern.json");
+        Assert.That(config.ResponseTo1NT?.Transfers?.Enabled, Is.True);
+        Assert.That(config.ResponseTo1NT?.Baron?.Enabled, Is.True);
+        Assert.That(config.ResponseTo1NT?.Baron?.Bid, Is.EqualTo("2S"));
+        Assert.That(config.Splinters?.Enabled, Is.True);
+        Assert.That(config.TrialBids?.Enabled, Is.True);
+    }
+
+    [Test]
+    public void SAYC_Has_FiveCardMajors_BetterMinor()
+    {
+        var config = LoadSystem("sayc.json");
+        Assert.That(config.SuitOpening?.MajorMinLength, Is.EqualTo(5));
+        Assert.That(config.SuitOpening?.MinorMinLength, Is.EqualTo(3));
+        Assert.That(config.SuitOpening?.MinorSelection, Is.EqualTo("BetterMinor"));
+        Assert.That(config.SuitOpening?.FourCardMajor, Is.Null);
+    }
+
+    [Test]
+    public void SAYC_Has_Strong1NT()
+    {
+        var config = LoadSystem("sayc.json");
+        Assert.That(config.NT1Opening?.MinHcp, Is.EqualTo(15));
+        Assert.That(config.NT1Opening?.MaxHcp, Is.EqualTo(17));
+    }
+
+    [Test]
+    public void SAYC_Has_Weak2D()
+    {
+        var config = LoadSystem("sayc.json");
+        Assert.That(config.TwoLevelOpenings?.WeakTwos?.Suits, Does.Contain("D"));
+        Assert.That(config.TwoLevelOpenings?.WeakTwos?.Suits, Does.Contain("H"));
+        Assert.That(config.TwoLevelOpenings?.WeakTwos?.Suits, Does.Contain("S"));
+    }
+
+    [Test]
+    public void Foundation_1NT_Is_12_14()
+    {
+        var config = LoadSystem("acol-foundation.json");
+        Assert.That(config.NT1Opening?.MinHcp, Is.EqualTo(12));
+        Assert.That(config.NT1Opening?.MaxHcp, Is.EqualTo(14));
+    }
+
+    [Test]
+    public void All_Acol_Systems_Have_4Card_Majors()
+    {
+        foreach (var file in new[] { "acol-foundation.json", "acol-benji.json", "acol-modern.json" })
+        {
+            var config = LoadSystem(file);
+            Assert.That(config.SuitOpening?.MajorMinLength, Is.EqualTo(4), $"Failed for {file}");
+            Assert.That(config.SuitOpening?.FourCardMajor, Is.Not.Null, $"Failed for {file}");
+        }
+    }
+
+    [Test]
+    public void Benji_SuitOpening_Is_11_HCP()
+    {
+        var config = LoadSystem("acol-benji.json");
+        Assert.That(config.SuitOpening?.MinHcp, Is.EqualTo(11));
+    }
+
+    [Test]
+    public void Foundation_And_Modern_SuitOpening_Is_12_HCP()
+    {
+        foreach (var file in new[] { "acol-foundation.json", "acol-modern.json" })
+        {
+            var config = LoadSystem(file);
+            Assert.That(config.SuitOpening?.MinHcp, Is.EqualTo(12), $"Failed for {file}");
+        }
+    }
+
+    // ── Loader tests ───────────────────────────────────────────────────────────
+
+    [Test]
+    public void Loader_Foundation_Produces_Expected_Rule_Count()
+    {
+        // Foundation Acol: no transfers (weakness takeouts instead)
+        // Expected: 5 openings + 2 Stayman (1NT, 2NT) + 1 NT raise + 1 response to 2C
+        //         + 5 responses to 1-suit + 1 opener rebid after 2C + 3 Stayman responses
+        //         + 3 responder after Stayman + 0 transfer completions (no transfers)
+        //         + 4 other opener rebids + 5 responder rebids + 6 knowledge = many
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
+        Assert.That(loaded.Rules, Is.Not.Empty);
+        Assert.That(loaded.Name, Is.EqualTo("Standard English Acol (Foundation)"));
+
+        // Log rule names for debugging
+        foreach (var rule in loaded.Rules)
+            TestContext.WriteLine($"  {rule.Priority:D2} {rule.Name}");
+    }
+
+    [Test]
+    public void Loader_Foundation_Rules_Are_Sorted_By_Priority_Descending()
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
+
+        for (int i = 1; i < loaded.Rules.Count; i++)
+        {
+            Assert.That(loaded.Rules[i].Priority, Is.LessThanOrEqualTo(loaded.Rules[i - 1].Priority),
+                $"Rule {loaded.Rules[i].Name} (priority {loaded.Rules[i].Priority}) should not appear after {loaded.Rules[i - 1].Name} (priority {loaded.Rules[i - 1].Priority})");
+        }
+    }
+
+    [Test]
+    public void Loader_Foundation_Has_Warnings_For_Unbuilt_Sections()
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
+        Assert.That(loaded.Warnings, Is.Not.Empty);
+        Assert.That(loaded.Warnings.Any(w => w.Contains("Overcalls")), Is.True);
+        Assert.That(loaded.Warnings.Any(w => w.Contains("Slam")), Is.True);
+        Assert.That(loaded.Warnings.Any(w => w.Contains("WeaknessTakeouts")), Is.True);
+    }
+
+    [Test]
+    public void Loader_Modern_Has_Transfer_Completions()
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-modern.json"));
+        // Modern Acol has transfers, so should have CompleteTransfer rules
+        Assert.That(loaded.Rules.Any(r => r.Name.Contains("Complete transfer")), Is.True);
+    }
+
+    [Test]
+    public void Loader_Foundation_Has_No_1NT_Transfer_Completions()
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
+        // Foundation has no transfers over 1NT (uses weakness takeouts instead)
+        Assert.That(loaded.Rules.Any(r => r.Name.Contains("Complete transfer after 1NT")), Is.False);
+    }
+
+    [TestCase("acol-foundation.json")]
+    [TestCase("acol-benji.json")]
+    [TestCase("acol-modern.json")]
+    [TestCase("sayc.json")]
+    public void Loader_All_Systems_Load_Without_Error(string filename)
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, filename));
+        Assert.That(loaded.Rules.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Loader_Foundation_KnowledgeSignOff_Is_Last()
+    {
+        var loader = new BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
+        Assert.That(loaded.Rules.Last().Name, Does.Contain("Sign off"));
+        Assert.That(loaded.Rules.Last().Priority, Is.EqualTo(0));
+    }
+}

--- a/BridgeIt.Tests/BridgeIt.Tests.csproj
+++ b/BridgeIt.Tests/BridgeIt.Tests.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\BridgeIt.Core\BridgeIt.Core.csproj" />
+      <ProjectReference Include="..\BridgeIt.Systems\BridgeIt.Systems.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BridgeIt.Tests/Rules/OpenerRebidPhase3aTests.cs
+++ b/BridgeIt.Tests/Rules/OpenerRebidPhase3aTests.cs
@@ -5,6 +5,7 @@ using BridgeIt.Core.BiddingEngine.Constraints;
 using BridgeIt.Core.BiddingEngine.Core;
 using BridgeIt.Core.Domain.Bidding;
 using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 
 namespace BridgeIt.Tests.Rules;
 
@@ -952,18 +953,8 @@ public class OpenerRebidPhase3aTests
     }
 
     private static BiddingRuleBase GetNTInviteRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolOpenerAfterNTInvite, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolOpenerAfterNTInvite not found. Create it at BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterNTInvite.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolOpenerAfterNTInvite();
 
     private static BiddingRuleBase GetAfterMajorRaiseRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolOpenerAfterMajorRaise, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolOpenerAfterMajorRaise not found. Create it at BiddingEngine/Rules/OpenerRebid/AcolOpenerAfterMajorRaise.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolOpenerAfterMajorRaise();
 }

--- a/BridgeIt.Tests/Rules/OpenerRebidPhase3bTests.cs
+++ b/BridgeIt.Tests/Rules/OpenerRebidPhase3bTests.cs
@@ -5,6 +5,7 @@ using BridgeIt.Core.BiddingEngine.Constraints;
 using BridgeIt.Core.BiddingEngine.Core;
 using BridgeIt.Core.Domain.Bidding;
 using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 
 namespace BridgeIt.Tests.Rules;
 
@@ -1072,34 +1073,14 @@ public class OpenerRebidPhase3bTests
     // =============================================================
 
     private static BiddingRuleBase GetRebidOwnSuitRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolRebidOwnSuit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRebidOwnSuit not found. Create it at BiddingEngine/Rules/OpenerRebid/AcolRebidOwnSuit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRebidOwnSuit();
 
     private static BiddingRuleBase GetRebidNewSuitRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolRebidNewSuit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRebidNewSuit not found. Create it at BiddingEngine/Rules/OpenerRebid/AcolRebidNewSuit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRebidNewSuit();
 
     private static BiddingRuleBase GetRebidBalancedRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolRebidBalanced, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRebidBalanced not found. It should already exist at BiddingEngine/Rules/OpenerRebid/AcolRebidBalanced.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRebidBalanced();
 
     private static BiddingRuleBase GetRebidRaiseSuitRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.OpenerRebid.AcolRebidRaiseSuit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRebidRaiseSuit not found. Create it at BiddingEngine/Rules/OpenerRebid/AcolRebidRaiseSuit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRebidRaiseSuit();
 }

--- a/BridgeIt.Tests/Rules/ResponseTo1SuitTests.cs
+++ b/BridgeIt.Tests/Rules/ResponseTo1SuitTests.cs
@@ -5,6 +5,7 @@ using BridgeIt.Core.BiddingEngine.Constraints;
 using BridgeIt.Core.BiddingEngine.Core;
 using BridgeIt.Core.Domain.Bidding;
 using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
 
 namespace BridgeIt.Tests.Rules;
 
@@ -1517,46 +1518,18 @@ public class ResponseTo1SuitTests
     // For now they use placeholder names matching the expected class names.
     // =============================================================
 
-    // TODO: Replace these with actual rule instantiation once implemented
-    // e.g.: private static BiddingRuleBase GetJacoby2NTRule() => new AcolJacoby2NTOver1Major();
-
     private static BiddingRuleBase GetJacoby2NTRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit.AcolJacoby2NTOver1Major, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolJacoby2NTOver1Major not found. Create it at BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolJacoby2NTOver1Major.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolJacoby2NTOver1Major();
 
     private static BiddingRuleBase GetRaiseMajorRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit.AcolRaiseMajorOver1Suit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRaiseMajorOver1Suit not found. Create it at BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMajorOver1Suit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRaiseMajorOver1Suit();
 
     private static BiddingRuleBase GetNewSuitRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit.AcolNewSuitOver1Suit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolNewSuitOver1Suit not found. Create it at BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolNewSuitOver1Suit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolNewSuitOver1Suit();
 
     private static BiddingRuleBase GetRaiseMinorRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit.AcolRaiseMinorOver1Suit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class AcolRaiseMinorOver1Suit not found. Create it at BiddingEngine/Rules/Responder/ResponsesTo1Suit/AcolRaiseMinorOver1Suit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new AcolRaiseMinorOver1Suit();
 
     private static BiddingRuleBase Get1NTResponseRule()
-    {
-        var type = Type.GetType("BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit.Acol1NTResponseTo1Suit, BridgeIt.Core");
-        Assert.That(type, Is.Not.Null,
-            "Rule class Acol1NTResponseTo1Suit not found. Create it at BiddingEngine/Rules/Responder/ResponsesTo1Suit/Acol1NTResponseTo1Suit.cs");
-        return (BiddingRuleBase)Activator.CreateInstance(type!)!;
-    }
+        => new Acol1NTResponseTo1Suit();
 }


### PR DESCRIPTION
…tions

Introduce a complete bidding system configuration layer that replaces hardcoded rule instantiation with JSON-driven system loading. This enables multi-system support, convention A/B toggling, and runtime system hot-swap via SignalR.

- Define typed config records for all convention card sections (openings, NT responses, suit responses, rebids, competitive, slam, convention toggles) in BridgeIt.Systems/Config/
- Create 4 system JSON files: Acol Foundation, Benji Acol, Modern Acol, and SAYC with full convention card data
- Build BiddingSystemLoader that instantiates rules from config, assigns priorities, and warns about unbuilt sections
- Refactor all 30+ rule classes to accept priority via constructor (opening rules also accept HCP/length config values)
- Add BiddingEngine.SetRules() for runtime rule hot-swap
- Replace 65-line inline rule list in Program.cs with loader call
- Update TestBridgeEnvironment to use loader
- Add LoadSystem SignalR endpoint to GameHub + GameService
- Add 30 config/loader tests, all 763 existing tests pass