### PR TITLE
Add competitive bidding: overcalls, takeout doubles, negative doubles

### DIFF
--- a/BridgeIt.Core/Analysis/Auction/AuctionEvaluation.cs
+++ b/BridgeIt.Core/Analysis/Auction/AuctionEvaluation.cs
@@ -21,16 +21,37 @@ public class AuctionEvaluation
     public Seat? NextSeatToBid { get; init; }
     public AuctionPhase AuctionPhase { get; init; }
     public int BiddingRound { get; init; }
+
+    // ── Competitive bidding properties ──────────────────────────────
+
+    /// <summary>Last non-pass bid made by right-hand opponent.</summary>
+    public Bid? RhoLastNonPassBid { get; init; }
+
+    /// <summary>Last non-pass bid made by left-hand opponent.</summary>
+    public Bid? LhoLastNonPassBid { get; init; }
+
+    /// <summary>Distinct suits bid by the opposing partnership.</summary>
+    public IReadOnlyList<Suit> OpponentBidSuits { get; init; } = Array.Empty<Suit>();
+
+    /// <summary>Suits not yet bid by anyone in the auction.</summary>
+    public IReadOnlyList<Suit> UnbidSuits { get; init; } = Array.Empty<Suit>();
+
+    /// <summary>True when acting immediately after an opponent's bid (direct seat).</summary>
+    public bool IsDirectSeat { get; init; }
+
+    /// <summary>True when acting in protective/balancing position (opponent bid, two passes, your turn).</summary>
+    public bool IsProtectiveSeat { get; init; }
 }
 
 public static class AuctionEvaluator
 {
     public static AuctionEvaluation Evaluate(AuctionHistory auctionHistory)
     {
+        var currentSeat = GetNextSeatToBid(auctionHistory);
 
         return new AuctionEvaluation()
         {
-            NextSeatToBid = GetNextSeatToBid(auctionHistory),
+            NextSeatToBid = currentSeat,
             CurrentContract = GetCurrentContract(auctionHistory),
             SeatRoleType = GetSeatRole(auctionHistory),
             OpeningBid = GetOpeningBid(auctionHistory),
@@ -40,6 +61,12 @@ public static class AuctionEvaluator
             OpeningSeat = GetOpeningSeat(auctionHistory),
             AuctionPhase = GetAuctionPhase(auctionHistory),
             BiddingRound = GetBiddingRound(auctionHistory),
+            RhoLastNonPassBid = GetRhoLastNonPassBid(auctionHistory, currentSeat),
+            LhoLastNonPassBid = GetLhoLastNonPassBid(auctionHistory, currentSeat),
+            OpponentBidSuits = GetOpponentBidSuits(auctionHistory, currentSeat),
+            UnbidSuits = GetUnbidSuits(auctionHistory),
+            IsDirectSeat = GetIsDirectSeat(auctionHistory, currentSeat),
+            IsProtectiveSeat = GetIsProtectiveSeat(auctionHistory, currentSeat),
         };
     }
     
@@ -121,12 +148,12 @@ public static class AuctionEvaluator
     public static SeatRoleType GetSeatRole(AuctionHistory auctionHistory)
     {
         var currentSeat = GetNextSeatToBid(auctionHistory);
-        
+
         var openingSeat = GetOpeningSeat(auctionHistory);
         if (openingSeat == null) return SeatRoleType.NoBids;
-        
+
         if (openingSeat == currentSeat) return SeatRoleType.Opener;
-        
+
         var difference = ((int)currentSeat - (int)openingSeat + 4) % 4;
 
         return difference switch
@@ -136,7 +163,87 @@ public static class AuctionEvaluator
             3 => SeatRoleType.Overcaller,
             _ => throw new ArgumentOutOfRangeException()
         };
-        
+
+    }
+
+    // ── Competitive bidding helpers ──────────────────────────────────
+
+    private static Bid? GetRhoLastNonPassBid(AuctionHistory history, Seat currentSeat)
+    {
+        // RHO is the seat immediately before currentSeat
+        var rho = ((int)currentSeat - 1 + 4) % 4;
+        var rhoSeat = (Seat)rho;
+        return history.Bids
+            .LastOrDefault(b => b.Seat == rhoSeat && b.Bid.Type != BidType.Pass)?.Bid;
+    }
+
+    private static Bid? GetLhoLastNonPassBid(AuctionHistory history, Seat currentSeat)
+    {
+        var lhoSeat = currentSeat.GetNextSeat();
+        return history.Bids
+            .LastOrDefault(b => b.Seat == lhoSeat && b.Bid.Type != BidType.Pass)?.Bid;
+    }
+
+    private static IReadOnlyList<Suit> GetOpponentBidSuits(AuctionHistory history, Seat currentSeat)
+    {
+        var partnerSeat = currentSeat.GetPartner();
+        return history.Bids
+            .Where(b => b.Seat != currentSeat && b.Seat != partnerSeat
+                        && b.Bid.Type == BidType.Suit && b.Bid.Suit.HasValue)
+            .Select(b => b.Bid.Suit!.Value)
+            .Distinct()
+            .ToList();
+    }
+
+    private static IReadOnlyList<Suit> GetUnbidSuits(AuctionHistory history)
+    {
+        var bidSuits = history.Bids
+            .Where(b => b.Bid.Type == BidType.Suit && b.Bid.Suit.HasValue)
+            .Select(b => b.Bid.Suit!.Value)
+            .ToHashSet();
+
+        return Enum.GetValues<Suit>().Where(s => !bidSuits.Contains(s)).ToList();
+    }
+
+    /// <summary>
+    /// Direct seat: the last bid in the auction (immediately before this seat)
+    /// was a non-pass bid by an opponent. i.e. RHO just bid.
+    /// </summary>
+    private static bool GetIsDirectSeat(AuctionHistory history, Seat currentSeat)
+    {
+        if (!history.Bids.Any()) return false;
+        var lastBid = history.Bids.Last();
+        var partnerSeat = currentSeat.GetPartner();
+        // Last bid was by RHO and was not a pass
+        return lastBid.Seat != currentSeat
+               && lastBid.Seat != partnerSeat
+               && lastBid.Bid.Type != BidType.Pass;
+    }
+
+    /// <summary>
+    /// Protective seat: opponent bid, then partner passed, then RHO passed, now it's our turn.
+    /// Pattern: opponent bid ... partner Pass, RHO Pass → current seat.
+    /// </summary>
+    private static bool GetIsProtectiveSeat(AuctionHistory history, Seat currentSeat)
+    {
+        if (history.Bids.Count < 3) return false;
+
+        var bids = history.Bids;
+        var last = bids[^1]; // RHO's bid (should be pass)
+        var secondLast = bids[^2]; // partner's bid (should be pass)
+
+        var partnerSeat = currentSeat.GetPartner();
+
+        // RHO passed, partner passed
+        if (last.Bid.Type != BidType.Pass) return false;
+        if (secondLast.Bid.Type != BidType.Pass || secondLast.Seat != partnerSeat) return false;
+
+        // The bid before that should be a non-pass by an opponent (LHO)
+        if (bids.Count < 3) return false;
+        var thirdLast = bids[^3];
+        return thirdLast.Seat != currentSeat
+               && thirdLast.Seat != partnerSeat
+               && thirdLast.Bid.Type != BidType.Pass;
     }
 }
 

--- a/BridgeIt.Core/BiddingEngine/Constraints/ShortageConstraint.cs
+++ b/BridgeIt.Core/BiddingEngine/Constraints/ShortageConstraint.cs
@@ -1,0 +1,26 @@
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Constraints;
+
+/// <summary>
+/// Constraint that checks the hand has at most <see cref="MaxLength"/> cards in a suit.
+/// Used for takeout double inference ("short in opponent's suit").
+/// </summary>
+public class ShortageConstraint : IBidConstraint
+{
+    public Suit Suit { get; }
+    public int MaxLength { get; }
+
+    public ShortageConstraint(Suit suit, int maxLength = 2)
+    {
+        Suit = suit;
+        MaxLength = maxLength;
+    }
+
+    public bool IsMet(DecisionContext ctx)
+    {
+        ctx.HandEvaluation.Shape.TryGetValue(Suit, out var count);
+        return count <= MaxLength;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/AdvanceAfterTakeoutDoubleRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/AdvanceAfterTakeoutDoubleRule.cs
@@ -1,0 +1,154 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+
+/// <summary>
+/// Advancing (responding to) partner's takeout double.
+/// Partner doubled → advancer MUST bid (unless RHO intervened).
+///
+/// Four tiers:
+///   0-8 HCP: bid best unbid suit at minimum level (forced response).
+///   9-11 HCP: jump in best suit (invitational).
+///   12+ HCP: cue bid opponent's suit (game-forcing).
+///   6-10 HCP + stopper + balanced: bid NT.
+/// </summary>
+public class AdvanceAfterTakeoutDoubleRule : BiddingRuleBase
+{
+    public override string Name => "Advance After Takeout Double";
+    public override int Priority { get; }
+
+    public AdvanceAfterTakeoutDoubleRule(int priority = 8)
+    {
+        Priority = priority;
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.MyLastNonPassBid == null
+           && auction.PartnerLastNonPassBid is { Type: BidType.Double };
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        // Always applicable when partner doubled — forced to bid
+        return true;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var hcp = ctx.HandEvaluation.Hcp;
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+
+        // 12+ HCP: cue bid opponent's suit (game-forcing)
+        if (hcp >= 12 && opponentSuits.Count > 0)
+        {
+            var oppSuit = opponentSuits[0];
+            var level = GetNextSuitBidLevel(oppSuit, currentContract);
+            if (level <= 4) return Bid.SuitBid(level, oppSuit);
+        }
+
+        // 6-10 HCP + stopper + balanced: bid NT
+        if (hcp >= 6 && hcp <= 10 && ctx.HandEvaluation.IsBalanced && HasStopperInOpponentSuit(ctx))
+        {
+            var ntLevel = GetNextNtBidLevel(currentContract);
+            if (ntLevel <= 2) return Bid.NoTrumpsBid(ntLevel);
+        }
+
+        // Find best unbid suit
+        var bestSuit = FindBestUnbidSuit(ctx);
+        if (bestSuit == null) return Bid.Pass(); // Shouldn't happen in practice
+
+        var cheapestLevel = GetNextSuitBidLevel(bestSuit.Value, currentContract);
+
+        // 9-11 HCP: jump in best suit (invitational)
+        if (hcp >= 9 && hcp <= 11)
+        {
+            var jumpLevel = cheapestLevel + 1;
+            return jumpLevel <= 4 ? Bid.SuitBid(jumpLevel, bestSuit.Value) : Bid.SuitBid(cheapestLevel, bestSuit.Value);
+        }
+
+        // 0-8 HCP: bid at minimum level
+        return cheapestLevel <= 4 ? Bid.SuitBid(cheapestLevel, bestSuit.Value) : Bid.Pass();
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx) => true; // Can explain any bid
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+
+        // Cue bid of opponent's suit = 12+ HCP
+        if (bid.Type == BidType.Suit && bid.Suit.HasValue && opponentSuits.Contains(bid.Suit.Value))
+        {
+            return new BidInformation(bid, new CompositeConstraint
+            {
+                Constraints = { new HcpConstraint(12, 40) }
+            }, PartnershipBiddingState.ConstructiveSearch);
+        }
+
+        // NT = 6-10 HCP, balanced
+        if (bid.Type == BidType.NoTrumps)
+        {
+            var constraints = new CompositeConstraint
+            {
+                Constraints = { new HcpConstraint(6, 10), new BalancedConstraint() }
+            };
+            if (opponentSuits.Count > 0)
+                constraints.Add(new StopperConstraint(opponentSuits[0]));
+            return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+        }
+
+        // Suit bid — check if it's a jump
+        if (bid.Type == BidType.Suit && bid.Suit.HasValue)
+        {
+            var cheapestLevel = GetNextSuitBidLevel(bid.Suit.Value, currentContract);
+            if (bid.Level > cheapestLevel)
+            {
+                // Jump = 9-11 HCP
+                return new BidInformation(bid, new CompositeConstraint
+                {
+                    Constraints = { new HcpConstraint(9, 11), new SuitLengthConstraint(bid.Suit.Value, 4, 13) }
+                }, PartnershipBiddingState.ConstructiveSearch);
+            }
+            else
+            {
+                // Minimum = 0-8 HCP
+                return new BidInformation(bid, new CompositeConstraint
+                {
+                    Constraints = { new HcpConstraint(0, 8) }
+                }, PartnershipBiddingState.ConstructiveSearch);
+            }
+        }
+
+        return null;
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction) => null;
+
+    private Suit? FindBestUnbidSuit(DecisionContext ctx)
+    {
+        var unbidSuits = ctx.AuctionEvaluation.UnbidSuits;
+        if (unbidSuits.Count == 0) return null;
+
+        // Pick the longest suit among unbid suits, prefer majors
+        return unbidSuits
+            .OrderByDescending(s => ctx.HandEvaluation.Shape.GetValueOrDefault(s, 0))
+            .ThenByDescending(s => s) // Higher rank preferred
+            .First();
+    }
+
+    private static bool HasStopperInOpponentSuit(DecisionContext ctx)
+    {
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count == 0) return true;
+        return opponentSuits.All(suit =>
+            ctx.HandEvaluation.SuitStoppers.TryGetValue(suit, out var quality)
+            && quality >= StopperQuality.Full);
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/NTResponseToOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/NTResponseToOvercallRule.cs
@@ -1,0 +1,86 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+
+/// <summary>
+/// 1NT response to partner's overcall.
+/// 8-11 HCP, balanced or semi-balanced, stopper in opponent's suit, no fit with partner.
+/// </summary>
+public class NTResponseToOvercallRule : BiddingRuleBase
+{
+    public override string Name => "NT Response to Overcall";
+    public override int Priority { get; }
+
+    public NTResponseToOvercallRule(int priority = 9)
+    {
+        Priority = priority;
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.MyLastNonPassBid == null
+           && auction.PartnerLastNonPassBid is { Type: BidType.Suit };
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        var hcp = ctx.HandEvaluation.Hcp;
+        if (hcp < 8 || hcp > 11) return false;
+
+        if (!ctx.HandEvaluation.IsBalanced) return false;
+
+        // No fit with partner (less than 3 cards in partner's suit)
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid!.Suit!.Value;
+        if (ctx.HandEvaluation.Shape[partnerSuit] >= 3) return false;
+
+        // Must have stopper in opponent's suit
+        return HasStopperInOpponentSuit(ctx);
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var level = GetNextNtBidLevel(ctx.AuctionEvaluation.CurrentContract);
+        return level <= 2 ? Bid.NoTrumpsBid(level) : null;
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+        => bid.Type == BidType.NoTrumps;
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.NoTrumps) return null;
+
+        var constraints = new CompositeConstraint
+        {
+            Constraints =
+            {
+                new HcpConstraint(8, 11),
+                new BalancedConstraint()
+            }
+        };
+
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count > 0)
+        {
+            constraints.Add(new StopperConstraint(opponentSuits[0]));
+        }
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction) => null;
+
+    private static bool HasStopperInOpponentSuit(DecisionContext ctx)
+    {
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count == 0) return true;
+
+        return opponentSuits.All(suit =>
+            ctx.HandEvaluation.SuitStoppers.TryGetValue(suit, out var quality)
+            && quality >= StopperQuality.Full);
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/NewSuitOverOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/NewSuitOverOvercallRule.cs
@@ -1,0 +1,84 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+
+/// <summary>
+/// New suit over partner's overcall — constructive, non-forcing.
+/// 5+ card suit, 8+ HCP, bid at cheapest level.
+/// </summary>
+public class NewSuitOverOvercallRule : BiddingRuleBase
+{
+    public override string Name => "New Suit Over Overcall";
+    public override int Priority { get; }
+
+    public NewSuitOverOvercallRule(int priority = 10)
+    {
+        Priority = priority;
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.MyLastNonPassBid == null           // Advancer
+           && auction.PartnerLastNonPassBid is { Type: BidType.Suit }; // Partner overcalled
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        if (ctx.HandEvaluation.Hcp < 8) return false;
+
+        return FindNewSuit(ctx) != null;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var suit = FindNewSuit(ctx);
+        if (suit == null) return null;
+
+        var level = GetNextSuitBidLevel(suit.Value, ctx.AuctionEvaluation.CurrentContract);
+        return level <= 3 ? Bid.SuitBid(level, suit.Value) : null;
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return false;
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid?.Suit;
+        return bid.Suit != partnerSuit; // Must be a different suit from partner's
+    }
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return null;
+
+        var constraints = new CompositeConstraint
+        {
+            Constraints =
+            {
+                new HcpConstraint(8, 40),
+                new SuitLengthConstraint(bid.Suit.Value, 5, 13)
+            }
+        };
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction) => null;
+
+    private Suit? FindNewSuit(DecisionContext ctx)
+    {
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid!.Suit!.Value;
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+        var candidates = ctx.HandEvaluation.SuitsWithMinLength(5);
+
+        foreach (var suit in candidates)
+        {
+            if (suit == partnerSuit) continue; // Must be a new suit
+            var level = GetNextSuitBidLevel(suit, currentContract);
+            if (level <= 3) return suit;
+        }
+
+        return null;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/RaiseOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/Advancer/RaiseOvercallRule.cs
@@ -1,0 +1,99 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+
+/// <summary>
+/// Raise partner's overcall suit.
+///   Simple raise: 3+ support, 8-11 HCP → raise by 1 level.
+///   Jump raise: 4+ support, 0-7 HCP → raise by 2 levels (preemptive).
+/// </summary>
+public class RaiseOvercallRule : BiddingRuleBase
+{
+    public override string Name => "Raise Partner's Overcall";
+    public override int Priority { get; }
+
+    public RaiseOvercallRule(int priority = 11)
+    {
+        Priority = priority;
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.MyLastNonPassBid == null           // I haven't bid yet (advancer)
+           && auction.PartnerLastNonPassBid is { Type: BidType.Suit }; // Partner made a suit overcall
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid!.Suit!.Value;
+        var support = ctx.HandEvaluation.Shape[partnerSuit];
+        var hcp = ctx.HandEvaluation.Hcp;
+
+        // Jump raise: 4+ support, 0-7 HCP
+        if (support >= 4 && hcp <= 7) return true;
+
+        // Simple raise: 3+ support, 8-11 HCP
+        if (support >= 3 && hcp >= 8 && hcp <= 11) return true;
+
+        return false;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid!.Suit!.Value;
+        var support = ctx.HandEvaluation.Shape[partnerSuit];
+        var hcp = ctx.HandEvaluation.Hcp;
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+
+        var cheapestLevel = GetNextSuitBidLevel(partnerSuit, currentContract);
+
+        // Jump raise (preemptive): 4+ support, weak
+        if (support >= 4 && hcp <= 7)
+        {
+            var jumpLevel = cheapestLevel + 1;
+            return jumpLevel <= 4 ? Bid.SuitBid(jumpLevel, partnerSuit) : null;
+        }
+
+        // Simple raise
+        return cheapestLevel <= 3 ? Bid.SuitBid(cheapestLevel, partnerSuit) : null;
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return false;
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid?.Suit;
+        return bid.Suit == partnerSuit;
+    }
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return null;
+        var partnerSuit = ctx.AuctionEvaluation.PartnerLastNonPassBid?.Suit;
+        if (bid.Suit != partnerSuit || !partnerSuit.HasValue) return null;
+
+        var cheapestLevel = GetNextSuitBidLevel(partnerSuit.Value, ctx.AuctionEvaluation.CurrentContract);
+        var isJump = bid.Level > cheapestLevel;
+
+        var constraints = new CompositeConstraint();
+        if (isJump)
+        {
+            // Jump raise: 4+ support, 0-7 HCP
+            constraints.Add(new SuitLengthConstraint(partnerSuit.Value, 4, 13));
+            constraints.Add(new HcpConstraint(0, 7));
+        }
+        else
+        {
+            // Simple raise: 3+ support, 8-11 HCP
+            constraints.Add(new SuitLengthConstraint(partnerSuit.Value, 3, 13));
+            constraints.Add(new HcpConstraint(8, 11));
+        }
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => null; // No meaningful negative inference from advancer passing
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/JumpOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/JumpOvercallRule.cs
@@ -1,0 +1,108 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive;
+
+/// <summary>
+/// Jump overcall — one level above the cheapest available bid.
+/// Two styles:
+///   "Intermediate" — 12-16 HCP, strong 6+ card suit.
+///   "Weak" — 6-10 HCP, pre-emptive 6+ card suit.
+/// Style is set by JumpOvercallConfig in the system JSON.
+/// </summary>
+public class JumpOvercallRule : BiddingRuleBase
+{
+    private readonly string _style;
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _minSuitLength;
+
+    public override string Name => $"Jump Overcall ({_style})";
+    public override int Priority { get; }
+
+    public JumpOvercallRule(string style = "Intermediate", int minHcp = 12, int maxHcp = 16,
+        int minSuitLength = 6, int priority = 14)
+    {
+        _style = style;
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _minSuitLength = minSuitLength;
+        Priority = priority;
+    }
+
+    private CompositeConstraint BuildConstraints()
+        => new()
+        {
+            Constraints =
+            {
+                new HcpConstraint(_minHcp, _maxHcp),
+                new SuitLengthConstraint("any", $">={_minSuitLength}")
+            }
+        };
+
+    private CompositeConstraint BuildConstraints(Suit suit)
+        => new()
+        {
+            Constraints =
+            {
+                new HcpConstraint(_minHcp, _maxHcp),
+                new SuitLengthConstraint(suit, _minSuitLength, 13)
+            }
+        };
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => BuildConstraints();
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.BiddingRound == 1
+           && auction.CurrentContract is { Type: BidType.Suit or BidType.NoTrumps };
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        var hcp = ctx.HandEvaluation.Hcp;
+        if (hcp < _minHcp || hcp > _maxHcp) return false;
+
+        return FindBestSuit(ctx) != null;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var suit = FindBestSuit(ctx);
+        if (suit == null) return null;
+
+        var cheapestLevel = GetNextSuitBidLevel(suit.Value, ctx.AuctionEvaluation.CurrentContract);
+        var jumpLevel = cheapestLevel + 1; // Jump = one level above cheapest
+        return jumpLevel <= 4 ? Bid.SuitBid(jumpLevel, suit.Value) : null;
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return false;
+        var cheapestLevel = GetNextSuitBidLevel(bid.Suit.Value, ctx.AuctionEvaluation.CurrentContract);
+        return bid.Level == cheapestLevel + 1; // Exactly a single jump
+    }
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return null;
+        return new BidInformation(bid, BuildConstraints(bid.Suit.Value), PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    private Suit? FindBestSuit(DecisionContext ctx)
+    {
+        var candidates = ctx.HandEvaluation.SuitsWithMinLength(_minSuitLength);
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+
+        foreach (var suit in candidates)
+        {
+            var cheapestLevel = GetNextSuitBidLevel(suit, currentContract);
+            if (cheapestLevel + 1 <= 4) return suit;
+        }
+
+        return null;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/NTOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/NTOvercallRule.cs
@@ -1,0 +1,115 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive;
+
+/// <summary>
+/// 1NT overcall — balanced hand with stopper in opponent's suit.
+/// Direct seat: typically 15-17 or 16-18 HCP.
+/// Protective seat: lower range, typically 11-14 HCP.
+/// </summary>
+public class NTOvercallRule : BiddingRuleBase
+{
+    private readonly int _directMinHcp;
+    private readonly int _directMaxHcp;
+    private readonly int _protectiveMinHcp;
+    private readonly int _protectiveMaxHcp;
+
+    public override string Name => "1NT Overcall";
+    public override int Priority { get; }
+
+    public NTOvercallRule(int directMinHcp = 15, int directMaxHcp = 17,
+        int protectiveMinHcp = 12, int protectiveMaxHcp = 14, int priority = 16)
+    {
+        _directMinHcp = directMinHcp;
+        _directMaxHcp = directMaxHcp;
+        _protectiveMinHcp = protectiveMinHcp;
+        _protectiveMaxHcp = protectiveMaxHcp;
+        Priority = priority;
+    }
+
+    /// <summary>
+    /// Forward constraints for negative inference — use the broadest range (direct).
+    /// Stopper is not included because we can't know the opponent's suit generically.
+    /// </summary>
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => new()
+        {
+            Constraints =
+            {
+                new HcpConstraint(_directMinHcp, _directMaxHcp),
+                new BalancedConstraint()
+            }
+        };
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.BiddingRound == 1
+           && auction.CurrentContract is { Type: BidType.Suit }  // Only over suit openings (not over NT)
+           && auction.CurrentContract.Level == 1;                 // Only over 1-level openings
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        if (!ctx.HandEvaluation.IsBalanced) return false;
+
+        var hcp = ctx.HandEvaluation.Hcp;
+        var isProtective = ctx.AuctionEvaluation.IsProtectiveSeat;
+
+        var minHcp = isProtective ? _protectiveMinHcp : _directMinHcp;
+        var maxHcp = isProtective ? _protectiveMaxHcp : _directMaxHcp;
+
+        if (hcp < minHcp || hcp > maxHcp) return false;
+
+        // Must have stopper in opponent's suit
+        return HasStopperInOpponentSuit(ctx);
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        return Bid.NoTrumpsBid(1);
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+        => bid.Type == BidType.NoTrumps && bid.Level == 1;
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.NoTrumps || bid.Level != 1) return null;
+
+        var constraints = new CompositeConstraint
+        {
+            Constraints =
+            {
+                new BalancedConstraint()
+            }
+        };
+
+        // Add stopper constraint for the opponent's suit if known
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count > 0)
+        {
+            constraints.Add(new StopperConstraint(opponentSuits[0]));
+        }
+
+        // Use the broader range for backward inference — could be direct or protective
+        constraints.Add(new HcpConstraint(
+            Math.Min(_directMinHcp, _protectiveMinHcp),
+            Math.Max(_directMaxHcp, _protectiveMaxHcp)));
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    private static bool HasStopperInOpponentSuit(DecisionContext ctx)
+    {
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count == 0) return true; // No opponent suit known
+
+        return opponentSuits.All(suit =>
+            ctx.HandEvaluation.SuitStoppers.TryGetValue(suit, out var quality)
+            && quality >= StopperQuality.Full);
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/NegativeDoubleRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/NegativeDoubleRule.cs
@@ -1,0 +1,114 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive;
+
+/// <summary>
+/// Negative double — by responder when opponent overcalls partner's opening.
+/// Shows 4+ in each unbid major, 6+ HCP.
+/// Only applies when opponent's overcall is at or below the configured maxLevel.
+/// </summary>
+public class NegativeDoubleRule : BiddingRuleBase
+{
+    private readonly Bid? _maxLevelBid;
+    private readonly int _minHcp;
+
+    public override string Name => "Negative Double";
+    public override int Priority { get; }
+
+    public NegativeDoubleRule(string maxLevel = "2S", int minHcp = 6, int priority = 12)
+    {
+        _minHcp = minHcp;
+        _maxLevelBid = ParseBidString(maxLevel);
+        Priority = priority;
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+    {
+        // Must be responder (partner opened) in a contested auction
+        if (auction.SeatRoleType != SeatRoleType.Responder) return false;
+        if (auction.AuctionPhase != AuctionPhase.Contested) return false;
+        if (auction.BiddingRound != 1) return false;
+
+        // RHO must have overcalled with a suit bid at or below max level
+        var rhoBid = auction.RhoLastNonPassBid;
+        if (rhoBid == null || rhoBid.Type != BidType.Suit) return false;
+
+        if (_maxLevelBid == null) return true;
+        return IsBidAtOrBelow(rhoBid, _maxLevelBid);
+    }
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        if (ctx.HandEvaluation.Hcp < _minHcp) return false;
+
+        // Must have 4+ in each unbid major
+        var unbidSuits = ctx.AuctionEvaluation.UnbidSuits;
+        var unbidMajors = unbidSuits.Where(s => s == Suit.Hearts || s == Suit.Spades).ToList();
+
+        if (unbidMajors.Count == 0) return false; // No unbid majors to show
+
+        return unbidMajors.All(major => ctx.HandEvaluation.Shape[major] >= 4);
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        return Bid.Double();
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+        => bid.Type == BidType.Double;
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Double) return null;
+
+        var constraints = new CompositeConstraint
+        {
+            Constraints = { new HcpConstraint(_minHcp, 40) }
+        };
+
+        // Add 4+ in each unbid major
+        var unbidSuits = ctx.AuctionEvaluation.UnbidSuits;
+        foreach (var suit in unbidSuits.Where(s => s == Suit.Hearts || s == Suit.Spades))
+        {
+            constraints.Add(new SuitLengthConstraint(suit, 4, 13));
+        }
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => new() { Constraints = { new HcpConstraint(_minHcp, 40) } };
+
+    public override bool IsAlertable => true;
+
+    private static Bid? ParseBidString(string bidStr)
+    {
+        if (string.IsNullOrWhiteSpace(bidStr) || bidStr.Length < 2) return null;
+        if (!int.TryParse(bidStr[..1], out var level)) return null;
+
+        var suitChar = bidStr[1..].ToUpper();
+        Suit? suit = suitChar switch
+        {
+            "C" => Suit.Clubs,
+            "D" => Suit.Diamonds,
+            "H" => Suit.Hearts,
+            "S" => Suit.Spades,
+            _ => null
+        };
+
+        return suit.HasValue ? Bid.SuitBid(level, suit.Value) : null;
+    }
+
+    private static bool IsBidAtOrBelow(Bid bid, Bid maxBid)
+    {
+        if (bid.Level < maxBid.Level) return true;
+        if (bid.Level > maxBid.Level) return false;
+        // Same level — compare suits
+        return bid.Suit <= maxBid.Suit;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/SimpleOvercallRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/SimpleOvercallRule.cs
@@ -1,0 +1,99 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive;
+
+/// <summary>
+/// Simple overcall at the cheapest level in a 5+ card suit.
+/// Direct seat: full HCP range (typically 8-15).
+/// Protective seat: lower threshold, can stretch to 4-card suit.
+///
+/// Priority should be above JumpOvercall but below NTOvercall.
+/// </summary>
+public class SimpleOvercallRule : BiddingRuleBase
+{
+    private readonly int _minHcp;
+    private readonly int _maxHcp;
+    private readonly int _minSuitLength;
+
+    public override string Name => "Simple Overcall";
+    public override int Priority { get; }
+
+    public SimpleOvercallRule(int minHcp = 8, int maxHcp = 15, int minSuitLength = 5, int priority = 15)
+    {
+        _minHcp = minHcp;
+        _maxHcp = maxHcp;
+        _minSuitLength = minSuitLength;
+        Priority = priority;
+    }
+
+    private CompositeConstraint BuildConstraints()
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint("any", $">={_minSuitLength}") } };
+
+    private CompositeConstraint BuildConstraints(Suit suit)
+        => new() { Constraints = { new HcpConstraint(_minHcp, _maxHcp), new SuitLengthConstraint(suit, _minSuitLength, 13) } };
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+        => BuildConstraints();
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.BiddingRound == 1
+           && auction.CurrentContract is { Type: BidType.Suit or BidType.NoTrumps };
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        var hcp = ctx.HandEvaluation.Hcp;
+        if (hcp < _minHcp || hcp > _maxHcp) return false;
+
+        // In protective seat, allow 4-card suits
+        var minLength = ctx.AuctionEvaluation.IsProtectiveSeat ? _minSuitLength - 1 : _minSuitLength;
+
+        return FindBestSuit(ctx, minLength) != null;
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        var minLength = ctx.AuctionEvaluation.IsProtectiveSeat ? _minSuitLength - 1 : _minSuitLength;
+        var suit = FindBestSuit(ctx, minLength);
+        if (suit == null) return null;
+
+        var level = GetNextSuitBidLevel(suit.Value, ctx.AuctionEvaluation.CurrentContract);
+        return level <= 3 ? Bid.SuitBid(level, suit.Value) : null; // Don't overcall at 4-level with minimum
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit) return false;
+        // Simple overcall = bid at cheapest possible level for this suit
+        var cheapestLevel = GetNextSuitBidLevel(bid.Suit!.Value, ctx.AuctionEvaluation.CurrentContract);
+        return bid.Level == cheapestLevel;
+    }
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Suit || !bid.Suit.HasValue) return null;
+        return new BidInformation(bid, BuildConstraints(bid.Suit.Value), PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    /// <summary>
+    /// Find the longest suit with at least minLength cards that can be bid above the current contract.
+    /// Prefers longer suits, then higher-ranking suits.
+    /// </summary>
+    private Suit? FindBestSuit(DecisionContext ctx, int minLength)
+    {
+        var candidates = ctx.HandEvaluation.SuitsWithMinLength(minLength);
+        var currentContract = ctx.AuctionEvaluation.CurrentContract;
+
+        foreach (var suit in candidates)
+        {
+            var level = GetNextSuitBidLevel(suit, currentContract);
+            if (level <= 3) return suit; // Can bid at a reasonable level
+        }
+
+        return null;
+    }
+}

--- a/BridgeIt.Core/BiddingEngine/Rules/Competitive/TakeoutDoubleRule.cs
+++ b/BridgeIt.Core/BiddingEngine/Rules/Competitive/TakeoutDoubleRule.cs
@@ -1,0 +1,100 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Core.BiddingEngine.Rules.Competitive;
+
+/// <summary>
+/// Takeout double — asks partner to bid their best suit.
+///
+/// Two qualifying paths:
+///   1. Classic shape: MinHcp+, 0-2 cards in opponent's suit, 3+ in each unbid suit.
+///   2. Strong override: StrongOverrideHcp+ regardless of shape (too strong to overcall).
+///
+/// Fires in both direct and protective seats over suit openings at level 1-3.
+/// </summary>
+public class TakeoutDoubleRule : BiddingRuleBase
+{
+    private readonly int _minHcp;
+    private readonly int _strongOverrideHcp;
+
+    public override string Name => "Takeout Double";
+    public override int Priority { get; }
+
+    public TakeoutDoubleRule(int minHcp = 12, int strongOverrideHcp = 16, int priority = 13)
+    {
+        _minHcp = minHcp;
+        _strongOverrideHcp = strongOverrideHcp;
+        Priority = priority;
+    }
+
+    public override CompositeConstraint? GetForwardConstraints(AuctionEvaluation auction)
+    {
+        // For negative inference: just use the HCP floor (the classic path minimum)
+        return new CompositeConstraint { Constraints = { new HcpConstraint(_minHcp, 40) } };
+    }
+
+    protected override bool IsApplicableContext(AuctionEvaluation auction)
+        => auction.SeatRoleType == SeatRoleType.Overcaller
+           && auction.BiddingRound == 1
+           && auction.CurrentContract is { Type: BidType.Suit }
+           && auction.CurrentContract.Level <= 3;
+
+    protected override bool IsHandApplicable(DecisionContext ctx)
+    {
+        var hcp = ctx.HandEvaluation.Hcp;
+        if (hcp < _minHcp) return false;
+
+        // Path 2: strong override — any shape with 16+ HCP
+        if (hcp >= _strongOverrideHcp) return true;
+
+        // Path 1: classic shape — short in opponent's suit, support for unbid suits
+        return HasClassicTakeoutShape(ctx);
+    }
+
+    public override Bid? Apply(DecisionContext ctx)
+    {
+        return Bid.Double();
+    }
+
+    protected override bool IsBidExplainable(Bid bid, DecisionContext ctx)
+        => bid.Type == BidType.Double;
+
+    public override BidInformation? GetConstraintForBid(Bid bid, DecisionContext ctx)
+    {
+        if (bid.Type != BidType.Double) return null;
+
+        // Backward inference: at minimum, HCP >= _minHcp
+        var constraints = new CompositeConstraint
+        {
+            Constraints = { new HcpConstraint(_minHcp, 40) }
+        };
+
+        return new BidInformation(bid, constraints, PartnershipBiddingState.ConstructiveSearch);
+    }
+
+    private bool HasClassicTakeoutShape(DecisionContext ctx)
+    {
+        var opponentSuits = ctx.AuctionEvaluation.OpponentBidSuits;
+        if (opponentSuits.Count == 0) return false;
+
+        // Short in opponent's suit (0-2 cards)
+        foreach (var oppSuit in opponentSuits)
+        {
+            if (ctx.HandEvaluation.Shape.TryGetValue(oppSuit, out var count) && count > 2)
+                return false;
+        }
+
+        // Support for all unbid suits (3+ cards in each)
+        var unbidSuits = ctx.AuctionEvaluation.UnbidSuits;
+        foreach (var suit in unbidSuits)
+        {
+            if (!ctx.HandEvaluation.Shape.TryGetValue(suit, out var count) || count < 3)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/BridgeIt.Systems/BiddingSystemLoader.cs
+++ b/BridgeIt.Systems/BiddingSystemLoader.cs
@@ -8,6 +8,8 @@ using BridgeIt.Core.BiddingEngine.Rules.OpenerRebid;
 using BridgeIt.Core.BiddingEngine.Rules.Responder;
 using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1NT;
 using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponsesTo1Suit;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
 using BridgeIt.Core.BiddingEngine.Rules.Responder.ResponderRebids;
 using BridgeIt.Core.Domain.Bidding;
 using BridgeIt.Core.Domain.Primatives;
@@ -242,9 +244,46 @@ public class BiddingSystemLoader
         rules.Add(new KnowledgeSignOffInFit());
         rules.Add(new KnowledgeSignOff());
 
-        // ── Warn about unbuilt sections ────────────────────────────────
-        WarnIfPresent(config.Overcalls, "Overcalls", warnings);
-        WarnIfPresent(config.NegativeDoubles, "NegativeDoubles", warnings);
+        // ── Overcalls ─────────────────────────────────────────────────
+        if (config.Overcalls is { } oc)
+        {
+            if (oc.Simple is { } simple)
+                rules.Add(new SimpleOvercallRule(simple.MinHcp, simple.MaxHcp,
+                    priority: GetPriority(priorities, "SimpleOvercall", 15)));
+
+            if (oc.Jump is { } jump)
+                rules.Add(new JumpOvercallRule(jump.Style, jump.MinHcp, jump.MaxHcp,
+                    jump.MinSuitLength, GetPriority(priorities, "JumpOvercall", 14)));
+
+            if (oc.NT1 is { } nt)
+                rules.Add(new NTOvercallRule(nt.DirectMinHcp, nt.DirectMaxHcp,
+                    nt.ProtectiveMinHcp, nt.ProtectiveMaxHcp,
+                    GetPriority(priorities, "NTOvercall", 16)));
+
+            if (oc.TakeoutDouble is { } td)
+                rules.Add(new TakeoutDoubleRule(td.MinHcp, td.StrongOverrideHcp,
+                    GetPriority(priorities, "TakeoutDouble", 13)));
+
+            // Advancer rules — responses to partner's overcall
+            rules.Add(new RaiseOvercallRule(GetPriority(priorities, "RaiseOvercall", 11)));
+            rules.Add(new NewSuitOverOvercallRule(GetPriority(priorities, "NewSuitOverOvercall", 10)));
+            rules.Add(new NTResponseToOvercallRule(GetPriority(priorities, "NTResponseToOvercall", 9)));
+
+            // Advance after takeout double
+            if (oc.TakeoutDouble is not null)
+                rules.Add(new AdvanceAfterTakeoutDoubleRule(GetPriority(priorities, "AdvanceAfterDouble", 8)));
+
+            WarnIfPresent(oc.CueBid, "CueBid (Michaels)", warnings);
+            WarnIfPresent(oc.Unusual2NT, "Unusual2NT", warnings);
+        }
+
+        // ── Negative doubles ──────────────────────────────────────────
+        if (config.NegativeDoubles is { Enabled: true } nd)
+        {
+            rules.Add(new NegativeDoubleRule(nd.MaxLevel, priority: GetPriority(priorities, "NegativeDouble", 12)));
+        }
+
+        // ── Competitive auction agreements (not yet implemented) ─────
         WarnIfPresent(config.CompetitiveAuctions, "CompetitiveAuctions", warnings);
         WarnIfPresent(config.Slam, "Slam", warnings);
         WarnIfPresent(config.FourthSuitForcing, "FourthSuitForcing", warnings);

--- a/BridgeIt.Systems/Config/CompetitiveConfigs.cs
+++ b/BridgeIt.Systems/Config/CompetitiveConfigs.cs
@@ -7,14 +7,28 @@ public record OvercallConfig
 {
     public SimpleOvercallConfig? Simple { get; init; }
     public JumpOvercallConfig? Jump { get; init; }
+    public TakeoutDoubleConfig? TakeoutDouble { get; init; }
     public CueBidOvercallConfig? CueBid { get; init; }
     public NTOvercallConfig? NT1 { get; init; }
     public UnusualNTConfig? Unusual2NT { get; init; }
 }
 
+/// <summary>
+/// Takeout double configuration.
+/// </summary>
+public record TakeoutDoubleConfig
+{
+    /// <summary>Minimum HCP for a classic shape takeout double.</summary>
+    public int MinHcp { get; init; }
+
+    /// <summary>HCP threshold above which any shape qualifies (too strong to overcall).</summary>
+    public int StrongOverrideHcp { get; init; }
+}
+
 public record SimpleOvercallConfig
 {
     public int MinHcp { get; init; }
+    public int MaxHcp { get; init; } = 15;
 }
 
 /// <summary>

--- a/BridgeIt.Systems/Systems/acol-benji.json
+++ b/BridgeIt.Systems/Systems/acol-benji.json
@@ -142,13 +142,14 @@
   "responderRebid": {},
 
   "overcalls": {
-    "simple": { "minHcp": 8 },
+    "simple": { "minHcp": 8, "maxHcp": 15 },
     "jump": {
       "style": "Weak",
       "minHcp": 6,
       "maxHcp": 10,
       "minSuitLength": 6
     },
+    "takeoutDouble": { "minHcp": 12, "strongOverrideHcp": 16 },
     "cueBid": {
       "enabled": true,
       "style": "Michaels",
@@ -237,6 +238,15 @@
     "AcolResponderAfterOpenerRebidOwnSuit": 40,
     "AcolResponderAfterOpenerNewSuit": 40,
     "AcolResponderAfter2CSuitRebid": 55,
+    "NTOvercall": 16,
+    "SimpleOvercall": 15,
+    "JumpOvercall": 14,
+    "TakeoutDouble": 13,
+    "RaiseOvercall": 11,
+    "NewSuitOverOvercall": 10,
+    "NegativeDouble": 12,
+    "NTResponseToOvercall": 9,
+    "AdvanceAfterDouble": 8,
     "KnowledgeShapeCorrection": 4,
     "KnowledgeBidGameInSuit": 2,
     "KnowledgeBidGameInNT": 1,

--- a/BridgeIt.Systems/Systems/acol-foundation.json
+++ b/BridgeIt.Systems/Systems/acol-foundation.json
@@ -128,13 +128,14 @@
   "responderRebid": {},
 
   "overcalls": {
-    "simple": { "minHcp": 8 },
+    "simple": { "minHcp": 8, "maxHcp": 15 },
     "jump": {
       "style": "Intermediate",
       "minHcp": 12,
       "maxHcp": 16,
       "minSuitLength": 6
     },
+    "takeoutDouble": { "minHcp": 12, "strongOverrideHcp": 16 },
     "cueBid": null,
     "nT1": {
       "directMinHcp": 15,
@@ -211,6 +212,15 @@
     "AcolResponderAfterOpenerRebidOwnSuit": 40,
     "AcolResponderAfterOpenerNewSuit": 40,
     "AcolResponderAfter2CSuitRebid": 55,
+    "NTOvercall": 16,
+    "SimpleOvercall": 15,
+    "JumpOvercall": 14,
+    "TakeoutDouble": 13,
+    "RaiseOvercall": 11,
+    "NewSuitOverOvercall": 10,
+    "NegativeDouble": 12,
+    "NTResponseToOvercall": 9,
+    "AdvanceAfterDouble": 8,
     "KnowledgeShapeCorrection": 4,
     "KnowledgeBidGameInSuit": 2,
     "KnowledgeBidGameInNT": 1,

--- a/BridgeIt.Systems/Systems/acol-modern.json
+++ b/BridgeIt.Systems/Systems/acol-modern.json
@@ -147,13 +147,14 @@
   "responderRebid": {},
 
   "overcalls": {
-    "simple": { "minHcp": 8 },
+    "simple": { "minHcp": 8, "maxHcp": 15 },
     "jump": {
       "style": "Intermediate",
       "minHcp": 12,
       "maxHcp": 16,
       "minSuitLength": 6
     },
+    "takeoutDouble": { "minHcp": 12, "strongOverrideHcp": 16 },
     "cueBid": {
       "enabled": true,
       "style": "Michaels",
@@ -245,6 +246,15 @@
     "AcolResponderAfterOpenerRebidOwnSuit": 40,
     "AcolResponderAfterOpenerNewSuit": 40,
     "AcolResponderAfter2CSuitRebid": 55,
+    "NTOvercall": 16,
+    "SimpleOvercall": 15,
+    "JumpOvercall": 14,
+    "TakeoutDouble": 13,
+    "RaiseOvercall": 11,
+    "NewSuitOverOvercall": 10,
+    "NegativeDouble": 12,
+    "NTResponseToOvercall": 9,
+    "AdvanceAfterDouble": 8,
     "KnowledgeShapeCorrection": 4,
     "KnowledgeBidGameInSuit": 2,
     "KnowledgeBidGameInNT": 1,

--- a/BridgeIt.Systems/Systems/sayc.json
+++ b/BridgeIt.Systems/Systems/sayc.json
@@ -125,13 +125,14 @@
   "responderRebid": {},
 
   "overcalls": {
-    "simple": { "minHcp": 8 },
+    "simple": { "minHcp": 8, "maxHcp": 15 },
     "jump": {
       "style": "Weak",
       "minHcp": 5,
       "maxHcp": 10,
       "minSuitLength": 6
     },
+    "takeoutDouble": { "minHcp": 12, "strongOverrideHcp": 16 },
     "cueBid": {
       "enabled": true,
       "style": "Michaels",
@@ -207,6 +208,15 @@
     "AcolResponderAfterOpenerRebidOwnSuit": 40,
     "AcolResponderAfterOpenerNewSuit": 40,
     "AcolResponderAfter2CSuitRebid": 55,
+    "NTOvercall": 16,
+    "SimpleOvercall": 15,
+    "JumpOvercall": 14,
+    "TakeoutDouble": 13,
+    "RaiseOvercall": 11,
+    "NewSuitOverOvercall": 10,
+    "NegativeDouble": 12,
+    "NTResponseToOvercall": 9,
+    "AdvanceAfterDouble": 8,
     "KnowledgeShapeCorrection": 4,
     "KnowledgeBidGameInSuit": 2,
     "KnowledgeBidGameInNT": 1,

--- a/BridgeIt.TestHarness/SystemTests/Acol/CompetitiveBiddingTests.cs
+++ b/BridgeIt.TestHarness/SystemTests/Acol/CompetitiveBiddingTests.cs
@@ -1,0 +1,169 @@
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+using BridgeIt.Dealer.HandSpecifications;
+using BridgeIt.TestHarness.Setup;
+using NUnit.Framework;
+
+namespace BridgeIt.TestHarness.SystemTests.Acol;
+
+/// <summary>
+/// System tests for competitive bidding: overcalls, takeout doubles,
+/// negative doubles, and responses to competitive bids.
+/// </summary>
+[TestFixture]
+public class CompetitiveBiddingTests
+{
+    private TestBridgeEnvironment _environment;
+    private Dealer.Deal.Dealer _dealer;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        _environment = TestBridgeEnvironment.Create().WithAllRules();
+        _dealer = new Dealer.Deal.Dealer();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // HAND SPECIFICATIONS FOR COMPETITIVE DEALS
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Simple overcall hand: 8-15 HCP, 5+ in target suit, no other 5+ suit
+    /// (to avoid the engine choosing the other suit).
+    /// </summary>
+    private static Func<Hand, bool> SimpleOvercallHand(Suit suit) => h =>
+    {
+        var hcp = HighCardPoints.Count(h);
+        var shape = ShapeEvaluator.GetShape(h);
+        return hcp >= 8 && hcp <= 15
+               && shape[suit] >= 5
+               && !ShapeEvaluator.IsBalanced(h)
+               // Ensure target suit is the longest (no competing 5+ suits)
+               && Enum.GetValues<Suit>().Where(s => s != suit).All(s => shape[s] < shape[suit]);
+    };
+
+    /// <summary>
+    /// Takeout double via strong override: 17+ HCP, no 5+ suit, not balanced.
+    /// Above overcall range, no long suit for jump overcall, not balanced for NT overcall.
+    /// </summary>
+    private static Func<Hand, bool> StrongTakeoutDoubleHand => h =>
+    {
+        var hcp = HighCardPoints.Count(h);
+        if (hcp < 17 || hcp > 20) return false;
+        var shape = ShapeEvaluator.GetShape(h);
+        if (ShapeEvaluator.IsBalanced(h)) return false;
+        // No 6+ suit (would trigger jump overcall)
+        if (shape.Values.Any(v => v >= 6)) return false;
+        return true;
+    };
+
+    /// <summary>Weak hand that should pass.</summary>
+    private static Func<Hand, bool> WeakPassHand => h =>
+        HighCardPoints.Count(h) < 8
+        && ShapeEvaluator.GetShape(h).Values.All(v => v < 6);
+
+    // ═══════════════════════════════════════════════════════════════
+    // SIMPLE OVERCALL TESTS
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task East_Overcalls1S_WhenNorthOpens1H()
+    {
+        // North opens 1H, East has overcall hand with 5+ spades.
+        var deals = _dealer.GenerateMultipleConstrainedDeals(20,
+            northConstraint: HandSpecification.AcolMajor1LevelOpening(Suit.Hearts),
+            eastConstraint: SimpleOvercallHand(Suit.Spades),
+            southConstraint: WeakPassHand,
+            westConstraint: WeakPassHand);
+
+        foreach (var deal in deals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            // North should open 1H
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1H"),
+                $"N should open 1H. Hand: {deal[Seat.North]}");
+
+            // East should overcall 1S
+            Assert.That(auction.Bids[1].Bid.ToString(), Is.EqualTo("1S"),
+                $"E should overcall 1S with hand: {deal[Seat.East]}");
+        }
+    }
+
+    [Test]
+    public async Task East_Overcalls2C_WhenNorthOpens1S()
+    {
+        // North opens 1S, East has 5+ clubs for 2C overcall.
+        var deals = _dealer.GenerateMultipleConstrainedDeals(20,
+            northConstraint: HandSpecification.AcolMajor1LevelOpening(Suit.Spades),
+            eastConstraint: SimpleOvercallHand(Suit.Clubs),
+            southConstraint: WeakPassHand,
+            westConstraint: WeakPassHand);
+
+        foreach (var deal in deals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1S"),
+                $"N should open 1S. Hand: {deal[Seat.North]}");
+
+            Assert.That(auction.Bids[1].Bid.ToString(), Is.EqualTo("2C"),
+                $"E should overcall 2C with hand: {deal[Seat.East]}");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TAKEOUT DOUBLE TESTS
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task East_Doubles_WhenNorthOpens1H_AndEastHasTakeoutShape()
+    {
+        // Use strong override (16+ HCP) — easier to generate than classic 4-4-4-1 shape
+        var deals = _dealer.GenerateMultipleConstrainedDeals(20,
+            northConstraint: HandSpecification.AcolMajor1LevelOpening(Suit.Hearts),
+            eastConstraint: StrongTakeoutDoubleHand,
+            southConstraint: WeakPassHand,
+            westConstraint: WeakPassHand);
+
+        foreach (var deal in deals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            Assert.That(auction.Bids[0].Bid.ToString(), Is.EqualTo("1H"),
+                $"N should open 1H. Hand: {deal[Seat.North]}");
+
+            // East should double (takeout)
+            Assert.That(auction.Bids[1].Bid.ToString(), Is.EqualTo("X"),
+                $"E should double (takeout) with hand: {deal[Seat.East]}");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // COMPETITIVE AUCTION COMPLETION
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task CompetitiveAuction_Completes_WithBothSidesBidding()
+    {
+        // North opens 1H, East overcalls 1S. Verify the auction terminates properly.
+        var deals = _dealer.GenerateMultipleConstrainedDeals(10,
+            northConstraint: HandSpecification.AcolMajor1LevelOpening(Suit.Hearts),
+            eastConstraint: SimpleOvercallHand(Suit.Spades));
+
+        foreach (var deal in deals)
+        {
+            var auction = await _environment.Table.RunAuction(deal, _environment.Players, Seat.North);
+
+            // Auction should have at least 4 bids (opening + overcall + 2 more)
+            Assert.That(auction.Bids.Count, Is.GreaterThanOrEqualTo(4),
+                "Competitive auction should have at least 4 bids");
+
+            // Should end with 3 consecutive passes
+            var lastThree = auction.Bids.TakeLast(3).ToList();
+            Assert.That(lastThree.All(b => b.Bid.Type == BidType.Pass), Is.True,
+                "Auction should end with 3 consecutive passes");
+        }
+    }
+}

--- a/BridgeIt.Tests/Analysis/Auction/AuctionEvaluationCompetitiveTests.cs
+++ b/BridgeIt.Tests/Analysis/Auction/AuctionEvaluationCompetitiveTests.cs
@@ -1,0 +1,207 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Analysis.Auction;
+
+/// <summary>
+/// Tests for competitive bidding properties on AuctionEvaluation:
+/// RhoLastNonPassBid, LhoLastNonPassBid, OpponentBidSuits, UnbidSuits,
+/// IsDirectSeat, IsProtectiveSeat.
+/// </summary>
+[TestFixture]
+public class AuctionEvaluationCompetitiveTests
+{
+    // ── RhoLastNonPassBid ──────────────────────────────────────────
+
+    [Test]
+    public void RhoLastNonPassBid_WhenRhoBidSuit_ReturnsThatBid()
+    {
+        // N opens 1H, E (RHO of S) overcalls 1S. South to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.SuitBid(1, Suit.Spades)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.RhoLastNonPassBid, Is.EqualTo(Bid.SuitBid(1, Suit.Spades)));
+    }
+
+    [Test]
+    public void RhoLastNonPassBid_WhenRhoPassed_ReturnsNull()
+    {
+        // N opens 1H, E passes. South to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.RhoLastNonPassBid, Is.Null);
+    }
+
+    // ── LhoLastNonPassBid ──────────────────────────────────────────
+
+    [Test]
+    public void LhoLastNonPassBid_WhenLhoBidSuit_ReturnsThatBid()
+    {
+        // N opens 1H, E passes, S bids 2H, W (LHO of N) overcalls 2S. North to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+        history.Add(new AuctionBid(Seat.South, Bid.SuitBid(2, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.West, Bid.SuitBid(2, Suit.Spades)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Next to bid is North. LHO of North = East.
+        // East passed, so LhoLastNonPassBid = null.
+        Assert.That(eval.LhoLastNonPassBid, Is.Null);
+    }
+
+    [Test]
+    public void LhoLastNonPassBid_ForEast_WhenNorthOpened()
+    {
+        // N opens 1H. East to bid. LHO of East = North = 1H.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Next to bid is East. LHO = South (hasn't bid). But North opened...
+        // LHO of East = South? No. Seat order: N→E→S→W. Next(E) = S. So LHO = S.
+        // North is RHO of East.
+        // Actually: LHO = the seat to the LEFT of current seat = the seat that bids AFTER.
+        // In bridge, LHO = left-hand opponent = next seat after you.
+        Assert.That(eval.LhoLastNonPassBid, Is.Null); // South hasn't bid
+    }
+
+    // ── OpponentBidSuits ──────────────────────────────────────────
+
+    [Test]
+    public void OpponentBidSuits_ReturnsOpponentsSuitBids()
+    {
+        // N opens 1H, E overcalls 1S. South to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.SuitBid(1, Suit.Spades)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // For South: opponents are East and West. East bid spades.
+        Assert.That(eval.OpponentBidSuits, Is.EquivalentTo(new[] { Suit.Spades }));
+    }
+
+    [Test]
+    public void OpponentBidSuits_WhenNoOpponentBids_ReturnsEmpty()
+    {
+        // N opens 1H, E passes. South to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.OpponentBidSuits, Is.Empty);
+    }
+
+    // ── UnbidSuits ─────────────────────────────────────────────────
+
+    [Test]
+    public void UnbidSuits_ExcludesBidSuits()
+    {
+        // N opens 1H, E overcalls 1S. Two suits bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.SuitBid(1, Suit.Spades)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.UnbidSuits, Is.EquivalentTo(new[] { Suit.Clubs, Suit.Diamonds }));
+    }
+
+    [Test]
+    public void UnbidSuits_WhenNoBids_ReturnAllFour()
+    {
+        var history = new AuctionHistory(Seat.North);
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.UnbidSuits, Has.Count.EqualTo(4));
+    }
+
+    // ── IsDirectSeat ──────────────────────────────────────────────
+
+    [Test]
+    public void IsDirectSeat_WhenRhoJustBid_ReturnsTrue()
+    {
+        // N opens 1H. East is in direct seat (RHO of East is North, and North just bid).
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Next = East. Last bid was North (opponent), non-pass.
+        Assert.That(eval.IsDirectSeat, Is.True);
+    }
+
+    [Test]
+    public void IsDirectSeat_WhenPartnerJustBid_ReturnsFalse()
+    {
+        // N opens 1H, E passes. South to bid. Last bid was E (pass).
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Last bid was East passing — it's a pass so not direct
+        Assert.That(eval.IsDirectSeat, Is.False);
+    }
+
+    // ── IsProtectiveSeat ──────────────────────────────────────────
+
+    [Test]
+    public void IsProtectiveSeat_AfterOpponentBidTwoPasses_ReturnsTrue()
+    {
+        // E opens 1H, S passes, W passes. North to bid (protective).
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.Pass()));
+        history.Add(new AuctionBid(Seat.East, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.South, Bid.Pass()));
+        history.Add(new AuctionBid(Seat.West, Bid.Pass()));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Next = North. Pattern: E bid, S pass, W pass → protective
+        Assert.That(eval.IsProtectiveSeat, Is.True);
+    }
+
+    [Test]
+    public void IsProtectiveSeat_WhenNotInProtectivePosition_ReturnsFalse()
+    {
+        // N opens 1H. East to bid (direct, not protective).
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        Assert.That(eval.IsProtectiveSeat, Is.False);
+    }
+
+    [Test]
+    public void IsProtectiveSeat_Standard4thSeat()
+    {
+        // N passes, E passes, S opens 1S, W passes. North to bid (protective? No — actually N already passed, not protective in the overcall sense. Let's test 4th seat after opening).
+        // N opens 1H, E passes, S passes. West to bid.
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, Bid.SuitBid(1, Suit.Hearts)));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+        history.Add(new AuctionBid(Seat.South, Bid.Pass()));
+
+        var eval = AuctionEvaluator.Evaluate(history);
+
+        // Next = West. Third-last = N (1H, opponent of W, non-pass). Second-last = E (pass, partner of W). Last = S (pass, opponent).
+        // Pattern: opponent (N) bid, partner (E) pass, RHO (S) pass → protective ✓
+        Assert.That(eval.IsProtectiveSeat, Is.True);
+    }
+}

--- a/BridgeIt.Tests/BiddingEngine/Constraints/ShortageConstraintTests.cs
+++ b/BridgeIt.Tests/BiddingEngine/Constraints/ShortageConstraintTests.cs
@@ -1,0 +1,78 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Constraints;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.BiddingEngine.Constraints;
+
+[TestFixture]
+public class ShortageConstraintTests
+{
+    private static DecisionContext MakeContext(Dictionary<Suit, int> shape)
+    {
+        var handEval = new HandEvaluation
+        {
+            Hcp = 12,
+            Shape = shape,
+            IsBalanced = false,
+            Losers = 7,
+            LongestAndStrongest = Suit.Spades
+        };
+
+        var history = new AuctionHistory(Seat.North);
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.North, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, new TableKnowledge(Seat.North));
+    }
+
+    [Test]
+    public void IsMet_WhenShortInSuit_ReturnsTrue()
+    {
+        var shape = new Dictionary<Suit, int>
+        {
+            { Suit.Spades, 4 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 1 }
+        };
+
+        var constraint = new ShortageConstraint(Suit.Clubs, 2);
+        Assert.That(constraint.IsMet(MakeContext(shape)), Is.True);
+    }
+
+    [Test]
+    public void IsMet_WhenVoidInSuit_ReturnsTrue()
+    {
+        var shape = new Dictionary<Suit, int>
+        {
+            { Suit.Spades, 5 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 0 }
+        };
+
+        var constraint = new ShortageConstraint(Suit.Clubs, 2);
+        Assert.That(constraint.IsMet(MakeContext(shape)), Is.True);
+    }
+
+    [Test]
+    public void IsMet_WhenTooLongInSuit_ReturnsFalse()
+    {
+        var shape = new Dictionary<Suit, int>
+        {
+            { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 }
+        };
+
+        var constraint = new ShortageConstraint(Suit.Clubs, 2);
+        Assert.That(constraint.IsMet(MakeContext(shape)), Is.False);
+    }
+
+    [Test]
+    public void IsMet_WhenExactlyAtMaxLength_ReturnsTrue()
+    {
+        var shape = new Dictionary<Suit, int>
+        {
+            { Suit.Spades, 4 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 }
+        };
+
+        var constraint = new ShortageConstraint(Suit.Clubs, 2);
+        Assert.That(constraint.IsMet(MakeContext(shape)), Is.True);
+    }
+}

--- a/BridgeIt.Tests/BiddingEngine/SystemConfigTests.cs
+++ b/BridgeIt.Tests/BiddingEngine/SystemConfigTests.cs
@@ -193,7 +193,7 @@ public class SystemConfigTests
         var loader = new BiddingSystemLoader();
         var loaded = loader.LoadFromFile(Path.Combine(SystemsDir, "acol-foundation.json"));
         Assert.That(loaded.Warnings, Is.Not.Empty);
-        Assert.That(loaded.Warnings.Any(w => w.Contains("Overcalls")), Is.True);
+        // Overcalls are now implemented (simple, jump, NT) — no longer warned
         Assert.That(loaded.Warnings.Any(w => w.Contains("Slam")), Is.True);
         Assert.That(loaded.Warnings.Any(w => w.Contains("WeaknessTakeouts")), Is.True);
     }

--- a/BridgeIt.Tests/Rules/AdvanceAfterDoubleTests.cs
+++ b/BridgeIt.Tests/Rules/AdvanceAfterDoubleTests.cs
@@ -1,0 +1,119 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Rules;
+
+[TestFixture]
+public class AdvanceAfterDoubleTests
+{
+    /// <summary>
+    /// N opens 1H, E (partner) doubles, S passes, W (advancer) to bid.
+    /// </summary>
+    private static DecisionContext CreateAdvanceContext(
+        Bid openingBid, int hcp, Dictionary<Suit, int> shape,
+        Dictionary<Suit, StopperQuality>? stoppers = null)
+    {
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+        history.Add(new AuctionBid(Seat.East, Bid.Double()));
+        history.Add(new AuctionBid(Seat.South, Bid.Pass()));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = shape.Values.OrderByDescending(v => v).ToArray() is [4, 3, 3, 3] or [4, 4, 3, 2] or [5, 3, 3, 2],
+            Losers = 7,
+            LongestAndStrongest = shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = stoppers ?? new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.West);
+        tableKnowledge.Partner.HcpMin = 12;
+        tableKnowledge.Partner.HcpMax = 40;
+
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.West, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    [Test]
+    public void MinimumResponse_WeakHand_BidsBestSuit()
+    {
+        // Partner doubled 1H. 5 HCP, 4 spades → bid 1S at minimum.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 5, shape);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(1, Suit.Spades)));
+    }
+
+    [Test]
+    public void InvitationalJump_9To11Hcp()
+    {
+        // Partner doubled 1H. 10 HCP, 4 spades → jump to 2S.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Spades)));
+    }
+
+    [Test]
+    public void CueBid_12PlusHcp()
+    {
+        // Partner doubled 1H. 14 HCP → cue bid 2H.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 14, shape);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Hearts)));
+    }
+
+    [Test]
+    public void NTResponse_WithStopper()
+    {
+        // Partner doubled 1H. 8 HCP, balanced, stopper in hearts → 1NT.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 3 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 8, shape, stoppers);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.NoTrumpsBid(1)));
+    }
+
+    [Test]
+    public void BackwardInference_CueBid_Shows12Plus()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 14, shape);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        var info = rule.GetConstraintForBid(Bid.SuitBid(2, Suit.Hearts), ctx);
+        Assert.That(info, Is.Not.Null);
+    }
+
+    [Test]
+    public void BackwardInference_MinimumBid_Shows0to8()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvanceContext(Bid.SuitBid(1, Suit.Hearts), 5, shape);
+
+        var rule = new AdvanceAfterTakeoutDoubleRule();
+        var info = rule.GetConstraintForBid(Bid.SuitBid(1, Suit.Spades), ctx);
+        Assert.That(info, Is.Not.Null);
+    }
+}

--- a/BridgeIt.Tests/Rules/AdvancerRuleTests.cs
+++ b/BridgeIt.Tests/Rules/AdvancerRuleTests.cs
@@ -1,0 +1,193 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive.Advancer;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Rules;
+
+[TestFixture]
+public class AdvancerRuleTests
+{
+    /// <summary>
+    /// N opens 1H, E (partner) overcalls 1S, S passes, W (advancer) to bid.
+    /// </summary>
+    private static DecisionContext CreateAdvancerContext(
+        Bid openingBid, Bid partnerOvercall, int hcp, Dictionary<Suit, int> shape,
+        Dictionary<Suit, StopperQuality>? stoppers = null)
+    {
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+        history.Add(new AuctionBid(Seat.East, partnerOvercall));
+        history.Add(new AuctionBid(Seat.South, Bid.Pass()));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = shape.Values.OrderByDescending(v => v).ToArray() is [4, 3, 3, 3] or [4, 4, 3, 2] or [5, 3, 3, 2],
+            Losers = 7,
+            LongestAndStrongest = shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = stoppers ?? new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.West);
+        // Partner overcalled — infer 5+ in their suit, 8-15 HCP
+        tableKnowledge.Partner.HcpMin = 8;
+        tableKnowledge.Partner.HcpMax = 15;
+        if (partnerOvercall.Suit.HasValue)
+            tableKnowledge.Partner.MinShape[partnerOvercall.Suit.Value] = 5;
+
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.West, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // RAISE OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void RaiseOvercall_SimpleRaise_3Support_8Hcp()
+    {
+        // Partner overcalled 1S. 3 spades, 9 HCP → raise to 2S.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 3 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 9, shape);
+
+        var rule = new RaiseOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Spades)));
+    }
+
+    [Test]
+    public void RaiseOvercall_JumpRaise_4Support_Weak()
+    {
+        // Partner overcalled 1S. 4 spades, 5 HCP → preemptive jump to 3S.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 5, shape);
+
+        var rule = new RaiseOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        // Cheapest for spades is 2S. Jump = 3S.
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(3, Suit.Spades)));
+    }
+
+    [Test]
+    public void RaiseOvercall_NoSupport_DoesNotApply()
+    {
+        // Partner overcalled 1S. Only 2 spades, 9 HCP → no raise.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 9, shape);
+
+        var rule = new RaiseOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void RaiseOvercall_TooManyHcp_ForSimpleRaise()
+    {
+        // 3 support, 13 HCP — too strong for simple raise (8-11).
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 3 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 13, shape);
+
+        var rule = new RaiseOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // NEW SUIT OVER OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NewSuit_5CardSuit_8Hcp()
+    {
+        // Partner overcalled 1S. 5 diamonds, 10 HCP → bid 2D.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 5 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 10, shape);
+
+        var rule = new NewSuitOverOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Diamonds)));
+    }
+
+    [Test]
+    public void NewSuit_TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 5 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 6, shape);
+
+        var rule = new NewSuitOverOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NewSuit_Only4Cards_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 10, shape);
+
+        var rule = new NewSuitOverOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // NT RESPONSE TO OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NTResponse_BalancedWithStopper_NoFit()
+    {
+        // Partner overcalled 1S. 2 spades (no fit), balanced, stopper in hearts, 10 HCP.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 10, shape, stoppers);
+
+        var rule = new NTResponseToOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void NTResponse_HasFit_DoesNotApply()
+    {
+        // 3+ support in partner's suit → should raise instead
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 3 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 10, shape, stoppers);
+
+        var rule = new NTResponseToOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NTResponse_NoStopper_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateAdvancerContext(
+            Bid.SuitBid(1, Suit.Hearts), Bid.SuitBid(1, Suit.Spades), 10, shape);
+
+        var rule = new NTResponseToOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+}

--- a/BridgeIt.Tests/Rules/NegativeDoubleTests.cs
+++ b/BridgeIt.Tests/Rules/NegativeDoubleTests.cs
@@ -1,0 +1,144 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Rules;
+
+[TestFixture]
+public class NegativeDoubleTests
+{
+    /// <summary>
+    /// N (partner) opens 1D, E overcalls 1H, S (responder) to bid.
+    /// </summary>
+    private static DecisionContext CreateNegativeDoubleContext(
+        Bid openingBid, Bid overcall, int hcp, Dictionary<Suit, int> shape)
+    {
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+        history.Add(new AuctionBid(Seat.East, overcall));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = false,
+            Losers = 7,
+            LongestAndStrongest = shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.South);
+        tableKnowledge.Partner.HcpMin = 12;
+        tableKnowledge.Partner.HcpMax = 19;
+        if (openingBid.Suit.HasValue)
+            tableKnowledge.Partner.MinShape[openingBid.Suit.Value] = 4;
+
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.South, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    [Test]
+    public void NegativeDouble_ShowsUnbidMajors()
+    {
+        // N opens 1D, E overcalls 1H. S has 8 HCP, 4 spades → negative double.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Diamonds), Bid.SuitBid(1, Suit.Hearts), 8, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.Double()));
+    }
+
+    [Test]
+    public void NegativeDouble_TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Diamonds), Bid.SuitBid(1, Suit.Hearts), 4, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NegativeDouble_NoUnbidMajor_DoesNotApply()
+    {
+        // N opens 1C, E overcalls 1S. Unbid majors = hearts only. S has only 3 hearts.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Clubs), Bid.SuitBid(1, Suit.Spades), 8, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NegativeDouble_4InUnbidMajor_Applies()
+    {
+        // N opens 1C, E overcalls 1S. S has 4 hearts → double.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Clubs), Bid.SuitBid(1, Suit.Spades), 8, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void NegativeDouble_OvercallAboveMaxLevel_DoesNotApply()
+    {
+        // maxLevel = 2S. Opponent overcalls at 3C → above limit.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Diamonds), Bid.SuitBid(3, Suit.Clubs), 10, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NegativeDouble_OvercallAt2Level_WithinLimit()
+    {
+        // N opens 1C, E overcalls 2D (within 2S limit). S has 4-4 majors.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 2 }, { Suit.Clubs, 3 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Clubs), Bid.SuitBid(2, Suit.Diamonds), 9, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void NegativeDouble_IsAlertable()
+    {
+        var rule = new NegativeDoubleRule();
+        Assert.That(rule.IsAlertable, Is.True);
+    }
+
+    [Test]
+    public void NegativeDouble_BackwardInference()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 3 } };
+        var ctx = CreateNegativeDoubleContext(
+            Bid.SuitBid(1, Suit.Diamonds), Bid.SuitBid(1, Suit.Hearts), 8, shape);
+
+        var rule = new NegativeDoubleRule("2S");
+        Assert.That(rule.CouldExplainBid(Bid.Double(), ctx), Is.True);
+        var info = rule.GetConstraintForBid(Bid.Double(), ctx);
+        Assert.That(info, Is.Not.Null);
+    }
+}

--- a/BridgeIt.Tests/Rules/OvercallRuleTests.cs
+++ b/BridgeIt.Tests/Rules/OvercallRuleTests.cs
@@ -1,0 +1,342 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Rules;
+
+[TestFixture]
+public class OvercallRuleTests
+{
+    // ═══════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Creates a context where North opens with the given bid, and East is the overcaller (direct seat).
+    /// </summary>
+    private static DecisionContext CreateDirectOvercallContext(
+        Bid openingBid, int hcp, Dictionary<Suit, int> shape,
+        Suit? longestSuit = null, Dictionary<Suit, StopperQuality>? stoppers = null)
+    {
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = shape.Values.OrderByDescending(v => v).ToArray() is [4, 3, 3, 3] or [4, 4, 3, 2] or [5, 3, 3, 2],
+            Losers = 7,
+            LongestAndStrongest = longestSuit ?? shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = stoppers ?? new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.East);
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.East, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    /// <summary>
+    /// Creates a context in protective seat: N opens, E passes, S passes, W to bid.
+    /// </summary>
+    private static DecisionContext CreateProtectiveOvercallContext(
+        Bid openingBid, int hcp, Dictionary<Suit, int> shape,
+        Suit? longestSuit = null, Dictionary<Suit, StopperQuality>? stoppers = null)
+    {
+        var history = new AuctionHistory(Seat.North);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+        history.Add(new AuctionBid(Seat.East, Bid.Pass()));
+        history.Add(new AuctionBid(Seat.South, Bid.Pass()));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = shape.Values.OrderByDescending(v => v).ToArray() is [4, 3, 3, 3] or [4, 4, 3, 2] or [5, 3, 3, 2],
+            Losers = 7,
+            LongestAndStrongest = longestSuit ?? shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = stoppers ?? new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.West);
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.West, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SIMPLE OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SimpleOvercall_1Level_OverOpponentOpening()
+    {
+        // N opens 1H. East has 10 HCP and 5 spades → overcall 1S.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(1, Suit.Spades)));
+    }
+
+    [Test]
+    public void SimpleOvercall_2Level_WhenSuitBelowOpening()
+    {
+        // N opens 1S. East has 10 HCP and 5 hearts → overcall 2H.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 2 }, { Suit.Hearts, 5 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Spades), 10, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Hearts)));
+    }
+
+    [Test]
+    public void SimpleOvercall_TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 6, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void SimpleOvercall_TooManyHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 17, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void SimpleOvercall_Only4CardSuit_DirectSeat_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void SimpleOvercall_4CardSuit_ProtectiveSeat_Applies()
+    {
+        // Protective seat allows 4-card overcalls
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateProtectiveOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new SimpleOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void SimpleOvercall_BackwardInference_ConstraintsForBid()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new SimpleOvercallRule();
+        var info = rule.GetConstraintForBid(Bid.SuitBid(1, Suit.Spades), ctx);
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.Bid, Is.EqualTo(Bid.SuitBid(1, Suit.Spades)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // JUMP OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void JumpOvercall_Intermediate_WithGoodSuit()
+    {
+        // N opens 1H. East has 14 HCP and 6 spades → jump to 2S.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 6 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 14, shape);
+
+        var rule = new JumpOvercallRule("Intermediate", 12, 16, 6);
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        // Cheapest for spades over 1H is 1S. Jump = 2S.
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(2, Suit.Spades)));
+    }
+
+    [Test]
+    public void JumpOvercall_Weak_WithLongSuit()
+    {
+        // N opens 1S. East has 7 HCP and 6 hearts → jump to 3H.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 1 }, { Suit.Hearts, 6 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 2 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Spades), 7, shape);
+
+        var rule = new JumpOvercallRule("Weak", 6, 10, 6);
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        // Cheapest for hearts over 1S is 2H. Jump = 3H.
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.SuitBid(3, Suit.Hearts)));
+    }
+
+    [Test]
+    public void JumpOvercall_TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 6 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new JumpOvercallRule("Intermediate", 12, 16, 6);
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void JumpOvercall_SuitTooShort_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 14, shape);
+
+        var rule = new JumpOvercallRule("Intermediate", 12, 16, 6);
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void JumpOvercall_BackwardInference()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 6 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 14, shape);
+
+        var rule = new JumpOvercallRule("Intermediate", 12, 16, 6);
+        // 2S is a jump over 1H (cheapest = 1S, jump = 2S)
+        Assert.That(rule.CouldExplainBid(Bid.SuitBid(2, Suit.Spades), ctx), Is.True);
+        // 1S is NOT a jump — it's the cheapest
+        Assert.That(rule.CouldExplainBid(Bid.SuitBid(1, Suit.Spades), ctx), Is.False);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // NT OVERCALL
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NTOvercall_Direct_BalancedWithStopper()
+    {
+        // N opens 1H. East has 16 HCP, balanced, stopper in hearts.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 16, shape, stoppers: stoppers);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.NoTrumpsBid(1)));
+    }
+
+    [Test]
+    public void NTOvercall_Direct_NoStopper_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 16, shape);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NTOvercall_Direct_NotBalanced_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 2 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 2 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 16, shape, stoppers: stoppers);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NTOvercall_Direct_TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 13, shape, stoppers: stoppers);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NTOvercall_Protective_LowerHcpRange()
+    {
+        // Protective seat: 12 HCP balanced with stopper should work.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateProtectiveOvercallContext(Bid.SuitBid(1, Suit.Hearts), 12, shape, stoppers: stoppers);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void NTOvercall_OverNTOpening_DoesNotApply()
+    {
+        // NT overcall only applies over suit openings
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateDirectOvercallContext(Bid.NoTrumpsBid(1), 16, shape);
+
+        var rule = new NTOvercallRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NTOvercall_BackwardInference()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var stoppers = new Dictionary<Suit, StopperQuality> { { Suit.Hearts, StopperQuality.Full } };
+        var ctx = CreateDirectOvercallContext(Bid.SuitBid(1, Suit.Hearts), 16, shape, stoppers: stoppers);
+
+        var rule = new NTOvercallRule(15, 17, 12, 14);
+        Assert.That(rule.CouldExplainBid(Bid.NoTrumpsBid(1), ctx), Is.True);
+        Assert.That(rule.CouldExplainBid(Bid.NoTrumpsBid(2), ctx), Is.False);
+
+        var info = rule.GetConstraintForBid(Bid.NoTrumpsBid(1), ctx);
+        Assert.That(info, Is.Not.Null);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // LOADER INTEGRATION
+    // ═══════════════════════════════════════════════════════════════
+
+    [Test]
+    public void Loader_Foundation_Includes_OvercallRules()
+    {
+        var systemsDir = Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "..", "..", "..", "..", "BridgeIt.Systems", "Systems");
+        var loader = new BridgeIt.Systems.BiddingSystemLoader();
+        var loaded = loader.LoadFromFile(Path.Combine(systemsDir, "acol-foundation.json"));
+
+        var ruleNames = loaded.Rules.Select(r => r.Name).ToList();
+        Assert.That(ruleNames, Does.Contain("Simple Overcall"));
+        Assert.That(ruleNames, Does.Contain("Jump Overcall (Intermediate)"));
+        Assert.That(ruleNames, Does.Contain("1NT Overcall"));
+    }
+}

--- a/BridgeIt.Tests/Rules/TakeoutDoubleTests.cs
+++ b/BridgeIt.Tests/Rules/TakeoutDoubleTests.cs
@@ -1,0 +1,136 @@
+using BridgeIt.Core.Analysis.Auction;
+using BridgeIt.Core.Analysis.Hands;
+using BridgeIt.Core.Analysis.Partnership;
+using BridgeIt.Core.BiddingEngine.Core;
+using BridgeIt.Core.BiddingEngine.Rules.Competitive;
+using BridgeIt.Core.Domain.Bidding;
+using BridgeIt.Core.Domain.Primatives;
+
+namespace BridgeIt.Tests.Rules;
+
+[TestFixture]
+public class TakeoutDoubleTests
+{
+    private static DecisionContext CreateOvercallContext(
+        Bid openingBid, int hcp, Dictionary<Suit, int> shape, Seat dealer = Seat.North)
+    {
+        // East is the overcaller in direct seat
+        var history = new AuctionHistory(dealer);
+        history.Add(new AuctionBid(Seat.North, openingBid));
+
+        var handEval = new HandEvaluation
+        {
+            Hcp = hcp,
+            Shape = shape,
+            IsBalanced = false,
+            Losers = 7,
+            LongestAndStrongest = shape.OrderByDescending(kv => kv.Value)
+                .ThenByDescending(kv => kv.Key).First().Key,
+            SuitStoppers = new Dictionary<Suit, StopperQuality>()
+        };
+
+        var aucEval = AuctionEvaluator.Evaluate(history);
+        var tableKnowledge = new TableKnowledge(Seat.East);
+        var ctx = new BiddingContext(new Hand(new List<Card>()), history, Seat.East, Vulnerability.None);
+        return new DecisionContext(ctx, handEval, aucEval, tableKnowledge);
+    }
+
+    [Test]
+    public void ClassicShape_ShortInOpponentSuit_SupportForUnbid()
+    {
+        // N opens 1H. East: 13 HCP, 4-1-4-4 (short in hearts).
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 1 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 13, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+        Assert.That(rule.Apply(ctx), Is.EqualTo(Bid.Double()));
+    }
+
+    [Test]
+    public void ClassicShape_VoidInOpponentSuit()
+    {
+        // N opens 1D. East: 12 HCP, 4-4-0-5 (void in diamonds).
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 4 }, { Suit.Diamonds, 0 }, { Suit.Clubs, 5 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Diamonds), 12, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void StrongOverride_AnyShape_16Plus()
+    {
+        // N opens 1H. East: 18 HCP, doesn't have classic shape (3 hearts).
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 5 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 2 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 18, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.True);
+    }
+
+    [Test]
+    public void TooFewHcp_DoesNotApply()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 1 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 10, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void NoShortageInOpponentSuit_BelowStrongOverride_DoesNotApply()
+    {
+        // 13 HCP but 3 cards in opponent's suit (not short enough) and not 16+ for override.
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 3 }, { Suit.Diamonds, 3 }, { Suit.Clubs, 3 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 13, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void OverNTOpening_DoesNotApply()
+    {
+        // Takeout double only over suit openings
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 1 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateOvercallContext(Bid.NoTrumpsBid(1), 13, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+
+    [Test]
+    public void BackwardInference_ExplainDouble()
+    {
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 4 }, { Suit.Hearts, 1 }, { Suit.Diamonds, 4 }, { Suit.Clubs, 4 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 13, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldExplainBid(Bid.Double(), ctx), Is.True);
+        Assert.That(rule.CouldExplainBid(Bid.SuitBid(1, Suit.Spades), ctx), Is.False);
+
+        var info = rule.GetConstraintForBid(Bid.Double(), ctx);
+        Assert.That(info, Is.Not.Null);
+    }
+
+    [Test]
+    public void LacksSupport_ForUnbidSuit_DoesNotApply()
+    {
+        // N opens 1H. East: 12 HCP, 1-1-2-9. Short in hearts but only 2 diamonds (not 3+).
+        var shape = new Dictionary<Suit, int>
+            { { Suit.Spades, 1 }, { Suit.Hearts, 1 }, { Suit.Diamonds, 2 }, { Suit.Clubs, 9 } };
+        var ctx = CreateOvercallContext(Bid.SuitBid(1, Suit.Hearts), 12, shape);
+
+        var rule = new TakeoutDoubleRule();
+        Assert.That(rule.CouldMakeBid(ctx), Is.False);
+    }
+}


### PR DESCRIPTION
Implement 10 new bidding rules for competitive auctions:

- SimpleOvercallRule: 8-15 HCP, 5+ suit (4+ in protective seat)
- JumpOvercallRule: Intermediate (12-16) or Weak (6-10), 6+ suit
- NTOvercallRule: balanced, stopper, direct 15-17 / protective 11-14
- TakeoutDoubleRule: classic shape or strong override (16+)
- NegativeDoubleRule: responder shows unbid majors after overcall
- RaiseOvercallRule: simple raise (8-11) / jump raise (0-7, preemptive)
- NewSuitOverOvercallRule: 5+ suit, 8+ HCP, non-forcing
- NTResponseToOvercallRule: balanced, stopper, no fit
- AdvanceAfterTakeoutDoubleRule: forced response with 4 strength tiers

Infrastructure: extend AuctionEvaluation with RhoLastNonPassBid, OpponentBidSuits, UnbidSuits, IsDirectSeat, IsProtectiveSeat. Add ShortageConstraint and TakeoutDoubleConfig.

Wire all rules into BiddingSystemLoader from existing config records. All 4 system JSONs updated with priorities and takeout double config.

864 unit tests + 4 system tests passing (up from 795).